### PR TITLE
Keep light map as matrix + only keep specific things from morphometry

### DIFF
--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -125,7 +125,7 @@ vol_light_map <- function(kd, light_incident, thresholds, depths){
   #Now we need to turn it to a volumetric light map, where TRUE means 
   # that layer (not just slice) is within the thresholds
   light_map_shifted <- light_map[,-1] # Effectively "moves" values of light_map over 1 column
-  light_map_to_compare <- light_map[,-ncol(light_map)] # Removes last column
+  light_map_to_compare <- light_map[,-ncol(light_map), drop=FALSE] # Removes last column
   vol_light_map <- light_map_shifted & light_map_to_compare # Compares each value to the value of the next column over
   
   return(vol_light_map)

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -8,6 +8,9 @@ extract_morphometry <- function(config_fn) {
   config <- fromJSON(config_fn)
   morphometry <- purrr::map(config, "morphometry")
   
-  return(morphometry)
+  # Only keep specific elements of morphometry
+  morphometry_out <- purrr::map(morphometry, `[`, c("latitude", "longitude", "H", "A"))
+  
+  return(morphometry_out)
 }
 


### PR DESCRIPTION
Fixes #3 & addresses last comment @jread-usgs made in #2 about limiting what we have in morphometry so that we don't trigger unnecessary rebuilds.