### PR TITLE
add calculation for max benthic area

### DIFF
--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -5,12 +5,15 @@ packages:
 
 sources:
   - 3_summarize/src/combine_files_to_zip.R
+  - 3_summarize/src/calculate_max_benthic_area.R
+  - 2_process/src/calculate_toha.R # Has the benthic area fxn
 
 targets:
   3_summarize:
     depends:
       - 3_summarize/out/3_summarize_zip_pb0_toha.yml
       - 3_summarize/out/3_summarize_zip_pgdl_toha.yml
+      - 3_summarize/out/max_benthic_areas.csv
 
   ### Zip up lake toha files by lake group ###
   
@@ -31,3 +34,13 @@ targets:
       files_to_zip_ind = '2_process/out/2_pgdl_lake_tasks.ind',
       dest_dir = I('3_summarize/tmp'),
       zip_out_prefix = I('pgdl_toha'))
+
+  ## Calculate max benthic area to use with TOHA areas --> TOHA as % Benthic Area ##
+  
+  all_lake_hypsography:
+    command: extract_hypsography(morphometry)
+  
+  3_summarize/out/max_benthic_areas.csv:
+    command: calculate_max_benthic_area(
+      target_name = target_name,
+      all_hypsos = all_lake_hypsography)

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -5,7 +5,7 @@ packages:
 
 sources:
   - 3_summarize/src/combine_files_to_zip.R
-  - 3_summarize/src/calculate_max_benthic_area.R
+  - 3_summarize/src/calculate_total_benthic_area.R
   - 2_process/src/calculate_toha.R # Has the benthic area fxn
 
 targets:
@@ -13,7 +13,7 @@ targets:
     depends:
       - 3_summarize/out/3_summarize_zip_pb0_toha.yml
       - 3_summarize/out/3_summarize_zip_pgdl_toha.yml
-      - 3_summarize/out/max_benthic_areas.csv
+      - 3_summarize/out/total_benthic_areas.csv
 
   ### Zip up lake toha files by lake group ###
   
@@ -35,12 +35,12 @@ targets:
       dest_dir = I('3_summarize/tmp'),
       zip_out_prefix = I('pgdl_toha'))
 
-  ## Calculate max benthic area to use with TOHA areas --> TOHA as % Benthic Area ##
+  ## Calculate total benthic area to use with TOHA areas --> TOHA as % Benthic Area ##
   
   all_lake_hypsography:
     command: extract_hypsography(morphometry)
   
-  3_summarize/out/max_benthic_areas.csv:
-    command: calculate_max_benthic_area(
+  3_summarize/out/total_benthic_areas.csv:
+    command: calculate_total_benthic_area(
       target_name = target_name,
       all_hypsos = all_lake_hypsography)

--- a/3_summarize/src/calculate_max_benthic_area.R
+++ b/3_summarize/src/calculate_max_benthic_area.R
@@ -1,0 +1,17 @@
+
+calculate_max_benthic_area <- function(target_name, all_hypsos) {
+  
+  purrr::map(all_hypsos, function(hypso) {
+    sum(benthic_areas(hypso$H, hypso$A))
+  }) %>%
+    # `enframe` required me to update tibble (I had `2.1.3` and now have `3.0.1`)
+    tibble::enframe(name = "site_id", value = "max_benthic_area") %>% 
+    tidyr::unnest(max_benthic_area) %>% 
+    readr::write_csv(target_name)
+  
+}
+
+extract_hypsography <- function(morphometry) {
+  # Only keep depths (H) and areas (A)
+  purrr::map(morphometry, `[`, c("H", "A"))
+}

--- a/3_summarize/src/calculate_total_benthic_area.R
+++ b/3_summarize/src/calculate_total_benthic_area.R
@@ -5,6 +5,7 @@ calculate_total_benthic_area <- function(target_name, all_hypsos) {
     sum(benthic_areas(hypso$H, hypso$A))
   }) %>%
     # `enframe` required me to update tibble (I had `2.1.3` and now have `3.0.1`)
+    # Takes a list and creates a two-column data.frame (one column is the names, one is the values)
     tibble::enframe(name = "site_id", value = "max_benthic_area") %>% 
     tidyr::unnest(max_benthic_area) %>% 
     readr::write_csv(target_name)

--- a/3_summarize/src/calculate_total_benthic_area.R
+++ b/3_summarize/src/calculate_total_benthic_area.R
@@ -1,5 +1,5 @@
 
-calculate_max_benthic_area <- function(target_name, all_hypsos) {
+calculate_total_benthic_area <- function(target_name, all_hypsos) {
   
   purrr::map(all_hypsos, function(hypso) {
     sum(benthic_areas(hypso$H, hypso$A))


### PR DESCRIPTION
Fixes #6. Creates 2 column data.frame with `site_id` which has the NHDHR lake id and `max_benthic_area` which has the summed benthic areas for each lake. Takes no time at all to run.

`scmake("3_summarize/out/max_benthic_areas.csv")`