### PR TITLE
add checks to verify that hypso is in assumed order (top to bottom)

### DIFF
--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -101,12 +101,12 @@ benthic_areas <- function(depths, areas){
   # Verify that depths & areas are listed from top to bottom
   # Our "depths" are actually "heights" above sea level. So the 
   # smaller the height, the deeper that profile.
-  corrected_order <- order(depths, decreasing = TRUE)
+  corrected_order <- order(depths)
   depths <- depths[corrected_order]
   areas <- areas[corrected_order]
   
   # Verify that our assumptions are correct
-  stopifnot(tail(depths, 1) == min(depths)) # bottom of lake is last in order
+  stopifnot(tail(depths, 1) == max(depths)) # bottom of lake is last in order
   stopifnot(tail(areas, 1) == min(areas)) # bottom of lake is smallest area
   
   areas_lead <- c(areas[-1], NA)

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -98,6 +98,17 @@ interp_hypso_to_match_temp_profiles <- function(wtr, hypso) {
 #  of benthic areas between each depth
 benthic_areas <- function(depths, areas){
   
+  # Verify that depths & areas are listed from top to bottom
+  # Our "depths" are actually "heights" above sea level. So the 
+  # smaller the height, the deeper that profile.
+  corrected_order <- order(depths, decreasing = TRUE)
+  depths <- depths[corrected_order]
+  areas <- areas[corrected_order]
+  
+  # Verify that our assumptions are correct
+  stopifnot(tail(depths, 1) == min(depths)) # bottom of lake is last in order
+  stopifnot(tail(areas, 1) == min(areas)) # bottom of lake is smallest area
+  
   areas_lead <- c(areas[-1], NA)
   depths_lead <- c(depths[-1], NA)
   

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -37,10 +37,7 @@ targets:
 
   ## Calculate total benthic area to use with TOHA areas --> TOHA as % Benthic Area ##
   
-  all_lake_hypsography:
-    command: extract_hypsography(morphometry)
-  
   3_summarize/out/total_benthic_areas.csv:
     command: calculate_total_benthic_area(
       target_name = target_name,
-      all_hypsos = all_lake_hypsography)
+      morphometry = morphometry)

--- a/3_summarize/src/calculate_total_benthic_area.R
+++ b/3_summarize/src/calculate_total_benthic_area.R
@@ -2,7 +2,7 @@
 calculate_total_benthic_area <- function(target_name, all_hypsos) {
   
   purrr::map(all_hypsos, function(hypso) {
-    sum(benthic_areas(hypso$H, hypso$A))
+    sum(benthic_areas(hypso$depths, hypso$areas))
   }) %>%
     # `enframe` required me to update tibble (I had `2.1.3` and now have `3.0.1`)
     # Takes a list and creates a two-column data.frame (one column is the names, one is the values)
@@ -13,6 +13,12 @@ calculate_total_benthic_area <- function(target_name, all_hypsos) {
 }
 
 extract_hypsography <- function(morphometry) {
-  # Only keep depths (H) and areas (A)
-  purrr::map(morphometry, `[`, c("H", "A"))
+  # Only keep depths (converted from Heights, H) and areas (A)
+  purrr::map(morphometry,  function(m) {
+    hypsos <- data.frame(H = m$H, A = m$A) %>% 
+      mutate(depths = max(H) - H, areas = A) %>% 
+      arrange(depths) %>% 
+      select(depths, areas)
+  })
+  
 }

--- a/3_summarize/src/calculate_total_benthic_area.R
+++ b/3_summarize/src/calculate_total_benthic_area.R
@@ -1,24 +1,14 @@
 
-calculate_total_benthic_area <- function(target_name, all_hypsos) {
+calculate_total_benthic_area <- function(target_name, morphometry) {
   
-  purrr::map(all_hypsos, function(hypso) {
-    sum(benthic_areas(hypso$depths, hypso$areas))
+  purrr::map(morphometry, function(m) {
+    # Order of depths & areas will be fixed in benthic_areas
+    sum(benthic_areas(depths = max(m$H) - m$H, areas = m$A))
   }) %>%
     # `enframe` required me to update tibble (I had `2.1.3` and now have `3.0.1`)
     # Takes a list and creates a two-column data.frame (one column is the names, one is the values)
     tibble::enframe(name = "site_id", value = "max_benthic_area") %>% 
     tidyr::unnest(max_benthic_area) %>% 
     readr::write_csv(target_name)
-  
-}
-
-extract_hypsography <- function(morphometry) {
-  # Only keep depths (converted from Heights, H) and areas (A)
-  purrr::map(morphometry,  function(m) {
-    hypsos <- data.frame(H = m$H, A = m$A) %>% 
-      mutate(depths = max(H) - H, areas = A) %>% 
-      arrange(depths) %>% 
-      select(depths, areas)
-  })
   
 }


### PR DESCRIPTION
Fixes #10 - the issue is that the depths/areas were not ordered from top to bottom. I thought they were but the "depths" we get are actually heights above sea level. So, the smaller the height, the deeper in the lake it pertains to. Added new checks to verify our assumptions.

One question - should I change the name of this argument from `depths` to `heights`? It might alleviate confusion in the future. 