### PR TITLE
Fix upsampled hyspo area approximation

### DIFF
--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -88,7 +88,14 @@ interp_hypso_to_match_temp_profiles <- function(wtr, hypso) {
   
   # Match hypso depths to water temperature profile depths
   matched_depths <- rLakeAnalyzer::get.offsets(wtr)
-  matched_areas <- approx(hypso$depths, hypso$areas, xout=matched_depths)$y
+  
+  # Linear relationship between depth and radius
+  hypso$radii <- sqrt(hypso$areas / pi)
+  matched_radii <- approx(hypso$depths, hypso$radii, xout=matched_depths)$y
+  
+  # Now calculate area from new radii
+  matched_areas <- pi * matched_radii^2
+  
   matched_hypso <- list(depths = matched_depths, areas = matched_areas)
   
   return(matched_hypso)

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -87,7 +87,7 @@ area_light_temp_threshold_shared <- function(wtr, kd, light_incident, irr_thresh
 interp_hypso_to_match_temp_profiles <- function(wtr, hypso) {
   
   # Match hypso depths to water temperature profile depths
-  matched_depths <- rLakeAnalyzer::get.offsets(wtr)
+  matched_depths <- c(hypso$depths, rLakeAnalyzer::get.offsets(wtr)) %>% unique() %>% sort
   
   # Linear relationship between depth and radius
   hypso$radii <- sqrt(hypso$areas / pi)

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -65,11 +65,14 @@ opti_thermal_habitat_subdaily <- function(current_date, wtr, io, kd, lat, lon, h
 #   calculating each vol map and then the areas.
 area_light_temp_threshold_shared <- function(wtr, kd, light_incident, irr_thresh=c(0,2000), wtr_thresh=c(0,25), hypso) {
   
+  # Upsample both hypsography & wtr so that they share depths
   updated_hypso <- interp_hypso_to_match_temp_profiles(wtr, hypso)
+  updated_wtr <- interp_temp_profiles_to_match_hypso(wtr, hypso)
+  
   depth_area_rel <- benthic_areas(updated_hypso$depths, updated_hypso$areas) # Calculate the depth to benthic area relationship
   
   light_map <- vol_light_map(kd, light_incident, irr_thresh, updated_hypso$depths)
-  wtr_map <- vol_temp_map(wtr, wtr_thresh) # wtr is just daily here; upsampled below to be able to compare to light
+  wtr_map <- vol_temp_map(updated_wtr, wtr_thresh) # wtr is just daily here; upsampled below to be able to compare to light
   
   # Upsample wtr (repeat values) to match dimensions of light_map, then compare light & temp
   wtr_upsampled_map <- matrix(wtr_map, ncol = ncol(wtr_map), nrow = length(light_incident), byrow=TRUE)
@@ -99,6 +102,39 @@ interp_hypso_to_match_temp_profiles <- function(wtr, hypso) {
   matched_hypso <- list(depths = matched_depths, areas = matched_areas)
   
   return(matched_hypso)
+}
+
+# Assumes that `wtr` colnames start with `temp_`
+interp_temp_profiles_to_match_hypso <- function(wtr, hypso) {
+  
+  matched_depths <- c(hypsos$depths, rLakeAnalyzer::get.offsets(wtr)) %>% unique() %>% sort
+  
+  # Figure out which will need to have interpolated wtr values
+  new_depths_i <- which(!matched_depths %in% rLakeAnalyzer::get.offsets(wtr))
+  
+  # Add new empty columns for new wtr depths & sort the data frame
+  wtr_matched <- wtr
+  wtr_matched[, paste0("temp_", matched_depths[new_depths_i])] <- NA
+  wtr_matched <- wtr_matched[, order(rLakeAnalyzer::get.offsets(wtr_matched))]
+  
+  # Interpolate wtr for each new column & then fill into the real data.frame
+  wtr_matched[, new_depths_i] <- purrr::map(new_depths_i, function(i) {
+    if(i == 1) {
+      # If the current new depth is the first depth in the profile, match the next wtr
+      wtr_new <- wtr_matched[i+1]
+    } else if(is.na(matched_depths[i+1])) {
+      # If the current new depth is the last depth in the profile, match the previous wtr
+      wtr_new <- wtr_matched[i-1] 
+    } else {
+      depth_ratio <- (matched_depths[i] - matched_depths[i-1]) / (matched_depths[i+1] - matched_depths[i-1])
+      wtr_new <- wtr_matched[i-1] + depth_ratio*(wtr_matched[i+1] - wtr_matched[i-1])
+    }
+    names(wtr_new) <- paste0("temp_", matched_depths[i])
+    return(wtr_new)
+  }) %>% 
+    purrr::reduce(cbind) 
+  
+  return(wtr_matched)
 }
 
 # Produces a vector of length n-1


### PR DESCRIPTION
Fixing issue with benthic areas from metadata being smaller than benthic areas of thermal habitat that Kelsey described. The problem comes up for the scenario where the lake thermal habitat is equal to all of the benthic area. The issue is that the thermal habitat is using the benthic area calculated with upsampled hypsos to match the temperature profiles. So, it ends up being larger than the total benthic area we put in the metadata file that is calculated with the original hypsos. 

Below are comparisons of the different outputs. `upsampled_areas_before` are results of the existing approximation and `upsampled_areas_after` are results with changes to the approximation in this PR. There is still a slight difference but I believe that is due to rounding errors and not real errors.

```
sum(benthic_areas(original_depths, original_areas)) # 281589.7
sum(benthic_areas(upsampled_depths, upsampled_areas_before)) # 281610.9, about 0.0075% higher
sum(benthic_areas(upsampled_depths, upsampled_areas_after)) # 281587.4, only 0.0008% less
```