### PR TITLE
Add observed temperature to pipeline & calculate TOHA

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -17,6 +17,8 @@ targets:
       - 1_fetch/out/pb0_temp_pred_downloaded.yml
       - 1_fetch/out/clarity_downloaded.yml
       - 1_fetch/out/temperature_observations.zip
+      - 1_fetch/out/pb0_matched_to_observations.zip
+      - 1_fetch/out/pgdl_matched_to_observations.zip
   
   sb_dl_date:
    command: c(I("2020-04-29"))
@@ -72,6 +74,8 @@ targets:
       dest_folder = I("1_fetch/tmp"),
       dummy = sb_dl_date)
   
+  ##-- Download files for error estimation --##
+  
   # All observed temperature data is in one
   # CSV file that is zipped up
   1_fetch/out/temperature_observations.zip:
@@ -79,4 +83,20 @@ targets:
       target_name = target_name,
       sb_id = I("5e5d0b68e4b01d50924f2b32"), 
       sb_filename = I("temperature_observations.zip"),
+      dummy = sb_dl_date)
+  
+  # PB0 temp data matched to obs depths and dates
+  1_fetch/out/pb0_matched_to_observations.zip:
+    command: download_sb_single_file(
+      target_name = target_name,
+      sb_id = I("5e774324e4b01d509270e29f"), 
+      sb_filename = I("pb0_matched_to_observations.zip"),
+      dummy = sb_dl_date)
+  
+  # PGDL temp data matched to obs depths and dates
+  1_fetch/out/pgdl_matched_to_observations.zip:
+    command: download_sb_single_file(
+      target_name = target_name,
+      sb_id = I("5e774324e4b01d509270e29f"), 
+      sb_filename = I("pgdl_matched_to_observations.zip"),
       dummy = sb_dl_date)

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -16,6 +16,7 @@ targets:
       - 1_fetch/out/irradiance_downloaded.yml
       - 1_fetch/out/pb0_temp_pred_downloaded.yml
       - 1_fetch/out/clarity_downloaded.yml
+      - 1_fetch/out/temperature_observations.zip
   
   sb_dl_date:
    command: c(I("2020-04-29"))
@@ -69,4 +70,13 @@ targets:
       sb_id = clarity_sbid, 
       keyword = I("clarity"), 
       dest_folder = I("1_fetch/tmp"),
+      dummy = sb_dl_date)
+  
+  # All observed temperature data is in one
+  # CSV file that is zipped up
+  1_fetch/out/temperature_observations.zip:
+    command: download_sb_single_file(
+      target_name = target_name,
+      sb_id = I("5e5d0b68e4b01d50924f2b32"), 
+      sb_filename = I("temperature_observations.zip"),
       dummy = sb_dl_date)

--- a/2_process.yml
+++ b/2_process.yml
@@ -121,13 +121,6 @@ targets:
       
   ### Calculate TOHA for each lake using observed temperature data ###
   
-  ## Split observed data into one file per lake ##
-  2_process/out/observed_temperatures_split.yml:
-    command: unzip_and_split_observed_data(
-      target_name = target_name,
-      obs_zipfile = "1_fetch/out/temperature_observations.zip",
-      split_file_prefix = I("2_process/tmp/split_obs_data"))
-  
   ## Prepare irradiance and clarity data for merging with observed temp by unzipping individual lake files ##
   2_process/out/irradiance_unzipped.yml:
     command: unzip_data(
@@ -140,15 +133,66 @@ targets:
       data_file = "1_fetch/out/clarity_downloaded.yml",
       out_dir = I("2_process/tmp"))
   
+  ## Split observed data into one file per lake ##
+  2_process/out/observed_temperatures_split.yml:
+    command: unzip_and_split_observed_data(
+      target_name = target_name,
+      obs_zipfile = "1_fetch/out/temperature_observations.zip",
+      split_file_prefix = I("2_process/tmp/split_obs_data"))
+  
   2_process/out/combined_obs_toha.csv:
     command: do_obs_lake_tasks(
       target_name = target_name,
       task_df_fn = '2_process/out/observed_temperatures_split.yml', 
       irr_df_fn = '2_process/out/irradiance_unzipped.yml',
       k0_df_fn = '2_process/out/clarity_unzipped.yml',
+      obs_model = I('obs'),
       "2_process/src/observed_data_helpers_munge.R", 
       "2_process/src/calculate_toha.R",
       "2_process/src/create_obs_lake_task_plan.R")
     depends:
       - morphometry
-    
+  
+  ### Now calculate TOHA for PB0 matched to observed ###
+  
+  ## Split data into one file per lake ##
+  2_process/out/pb0_matched2obs_split.yml:
+    command: unzip_and_split_observed_data(
+      target_name = target_name,
+      obs_zipfile = "1_fetch/out/pb0_matched_to_observations.zip",
+      split_file_prefix = I("2_process/tmp/split_pb0_matched2obs_data"))
+  
+  2_process/out/combined_pb0_matched2obs_toha.csv:
+    command: do_obs_lake_tasks(
+      target_name = target_name,
+      task_df_fn = '2_process/out/pb0_matched2obs_split.yml', 
+      irr_df_fn = '2_process/out/irradiance_unzipped.yml',
+      k0_df_fn = '2_process/out/clarity_unzipped.yml',
+      obs_model = I('pb0_matched2obs'),
+      "2_process/src/observed_data_helpers_munge.R", 
+      "2_process/src/calculate_toha.R",
+      "2_process/src/create_obs_lake_task_plan.R")
+    depends:
+      - morphometry
+  
+  ### Now calculate TOHA for PGDL matched to observed ###
+  
+  ## Split data into one file per lake ##
+  2_process/out/pgdl_matched2obs_split.yml:
+    command: unzip_and_split_observed_data(
+      target_name = target_name,
+      obs_zipfile = "1_fetch/out/pgdl_matched_to_observations.zip",
+      split_file_prefix = I("2_process/tmp/split_pgdl_matched2obs_data"))
+  
+  2_process/out/combined_pgdl_matched2obs_toha.csv:
+    command: do_obs_lake_tasks(
+      target_name = target_name,
+      task_df_fn = '2_process/out/pgdl_matched2obs_split.yml', 
+      irr_df_fn = '2_process/out/irradiance_unzipped.yml',
+      k0_df_fn = '2_process/out/clarity_unzipped.yml',
+      obs_model = I('pgdl_matched2obs'),
+      "2_process/src/observed_data_helpers_munge.R", 
+      "2_process/src/calculate_toha.R",
+      "2_process/src/create_obs_lake_task_plan.R")
+    depends:
+      - morphometry

--- a/2_process.yml
+++ b/2_process.yml
@@ -4,11 +4,15 @@ packages:
   - dplyr
   - tidyr
   - scipiper
+  - readr
+  - feather
+  - purrr
 
 sources:
   - 2_process/src/process_helpers.R
   - 2_process/src/create_group_task_plan.R
   - 2_process/src/create_lake_task_plan.R
+  - 2_process/src/split_observed_data.R
 
 targets:
   2_process:
@@ -70,8 +74,10 @@ targets:
       - 1_fetch/out/irradiance_downloaded.yml
       - 1_fetch/out/pb0_temp_pred_downloaded.yml
       - 1_fetch/out/clarity_downloaded.yml
+  
   ### Calculate TOHA for each lake ###
   
+  ## For PB0 ##
   process_lake_tasks:
     command: create_lake_tasks(task_df_fn = '2_process/out/2_process_grp_tasks_completed.yml', 
       log_folder = I("2_process/log"))
@@ -90,7 +96,7 @@ targets:
       - morphometry
       - 2_process/out/2_process_grp_tasks_completed.yml
 
-   ## now PGDL
+  ## For PGDL ##
   pgdl_lake_tasks:
     command: create_lake_tasks(task_df_fn = '2_process/out/2_pgdl_grp_tasks_completed.yml', 
       log_folder = I("2_process/log"))
@@ -102,11 +108,20 @@ targets:
       remake_file = I('2_process.yml'),
       final_targets = I('2_process/out/2_pgdl_lake_tasks.ind'))
   
-        #'2_process/tmp/pgdl_toha_nhdhr_120018569.csv', FAILED!!!Error in seq.int(0, to0 - from, by) : 'to' must be a finite number
-#In addition: There were 50 or more warnings (use warnings() to see the first 50)
+  #'2_process/tmp/pgdl_toha_nhdhr_120018569.csv', FAILED!!!Error in seq.int(0, to0 - from, by) : 'to' must be a finite number
+  #In addition: There were 50 or more warnings (use warnings() to see the first 50)
   2_process/out/2_pgdl_lake_tasks.ind:
     command: scmake(
       target_names = I('2_pgdl_lake_tasks.ind_promise'),
       remake_file = '2_pgdl_lake_tasks.yml')
     depends:
       - morphometry
+      
+  ### Calculate TOHA for each lake using observed temperature data ###
+  
+  ## Split observed data into one file per lake ##
+  2_process/out/observed_temperatures_split.yml:
+    command: split_observed_data(
+      target_name = target_name,
+      obs_zipfile = "1_fetch/out/temperature_observations.zip",
+      split_file_prefix = "split_obs_data")

--- a/2_process.yml
+++ b/2_process.yml
@@ -126,7 +126,7 @@ targets:
     command: unzip_and_split_observed_data(
       target_name = target_name,
       obs_zipfile = "1_fetch/out/temperature_observations.zip",
-      split_file_prefix = I("split_obs_data"))
+      split_file_prefix = I("2_process/tmp/split_obs_data"))
   
   ## Prepare irradiance and clarity data for merging with observed temp by unzipping individual lake files ##
   2_process/out/irradiance_unzipped.yml:

--- a/2_process.yml
+++ b/2_process.yml
@@ -12,13 +12,15 @@ sources:
   - 2_process/src/process_helpers.R
   - 2_process/src/create_group_task_plan.R
   - 2_process/src/create_lake_task_plan.R
-  - 2_process/src/split_observed_data.R
+  - 2_process/src/observed_data_helpers_prepare.R
+  - 2_process/src/create_obs_lake_task_plan.R
 
 targets:
   2_process:
     depends:
       - 2_process/out/2_process_lake_tasks.ind
       - 2_process/out/2_pgdl_lake_tasks.ind
+      - 2_process/out/combined_obs_toha.csv
   
   sb_group_info:
     command: read_csv("1_fetch/out/lake_metadata.csv")
@@ -121,7 +123,32 @@ targets:
   
   ## Split observed data into one file per lake ##
   2_process/out/observed_temperatures_split.yml:
-    command: split_observed_data(
+    command: unzip_and_split_observed_data(
       target_name = target_name,
       obs_zipfile = "1_fetch/out/temperature_observations.zip",
-      split_file_prefix = "split_obs_data")
+      split_file_prefix = I("split_obs_data"))
+  
+  ## Prepare irradiance and clarity data for merging with observed temp by unzipping individual lake files ##
+  2_process/out/irradiance_unzipped.yml:
+    command: unzip_data(
+      target_name = target_name,
+      data_file = "1_fetch/out/irradiance_downloaded.yml",
+      out_dir = I("2_process/tmp"))
+  2_process/out/clarity_unzipped.yml:
+    command: unzip_data(
+      target_name = target_name,
+      data_file = "1_fetch/out/clarity_downloaded.yml",
+      out_dir = I("2_process/tmp"))
+  
+  2_process/out/combined_obs_toha.csv:
+    command: do_obs_lake_tasks(
+      target_name = target_name,
+      task_df_fn = '2_process/out/observed_temperatures_split.yml', 
+      irr_df_fn = '2_process/out/irradiance_unzipped.yml',
+      k0_df_fn = '2_process/out/clarity_unzipped.yml',
+      "2_process/src/observed_data_helpers_munge.R", 
+      "2_process/src/calculate_toha.R",
+      "2_process/src/create_obs_lake_task_plan.R")
+    depends:
+      - morphometry
+    

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -6,37 +6,48 @@ calculate_toha_per_lake <- function(target_name, site_data_fn, morphometry) {
   site_data <- feather::read_feather(site_data_fn)
   wtr_cols <- grep("temp_", names(site_data))
   
-  hypsos <- data.frame(H = morphometry$H, A = morphometry$A) %>% 
-    mutate(depths = max(H) - H, areas = A) %>% 
-    arrange(depths) %>% 
-    select(depths, areas)
+  # When adding obs data, some sites don't make it past the filtering criteria
+  # so we need to skip them or toha calculations error weirdly
+  if(nrow(site_data) == 0) {
+    # Can't use `site_data` since there aren't any observations
+    site_id <- sub(pattern = ".*(nhdhr_.*)\\..*$", replacement = "\\1", target_name)
+    warning(sprintf("Insufficient data to calculate TOHA for %s", site_id))
+    data.frame() %>% readr::write_csv(path = target_name)
+  } else {
+    
+    hypsos <- data.frame(H = morphometry$H, A = morphometry$A) %>% 
+      mutate(depths = max(H) - H, areas = A) %>% 
+      arrange(depths) %>% 
+      select(depths, areas)
+    
+    # precalculate benthic areas for each known slice, rather than doing
+    # this for each time timestep
+    cum_benthic_area <- cumsum(calc_benthic_area(
+      hypsos$depths[-length(hypsos$depths)],
+      hypsos$depths[-1],
+      hypsos$areas[-length(hypsos$areas)],
+      hypsos$areas[-1]))
+    
+    toha_out <- purrr::map(1:nrow(site_data), function(r) {
+      opti_thermal_habitat_subdaily(
+        current_date = site_data$DateTime[r],
+        wtr = site_data[r, wtr_cols], 
+        io = site_data$io[r], 
+        kd = site_data$kd[r], 
+        lat = morphometry$latitude, 
+        lon = morphometry$longitude, 
+        hypsos = hypsos, 
+        irr_thresh = c(0.0762, 0.6476), 
+        wtr_thresh = c(11,25),
+        cum_ba = cum_benthic_area)
+    }) %>% 
+      purrr::reduce(bind_rows) %>% 
+      mutate(date = site_data$DateTime) %>% # Add the date column
+      mutate(site_id = site_data$site_id) %>% # Add the site column
+      select(site_id, date, everything()) %>% # Move site and date columns first
+      readr::write_csv(path = target_name)
+  }
   
-  # precalculate benthic areas for each known slice, rather than doing
-  # this for each time timestep
-  cum_benthic_area <- cumsum(calc_benthic_area(
-    hypsos$depths[-length(hypsos$depths)],
-    hypsos$depths[-1],
-    hypsos$areas[-length(hypsos$areas)],
-    hypsos$areas[-1]))
-  
-  toha_out <- purrr::map(1:nrow(site_data), function(r) {
-    opti_thermal_habitat_subdaily(
-      current_date = site_data$DateTime[r],
-      wtr = site_data[r, wtr_cols], 
-      io = site_data$io[r], 
-      kd = site_data$kd[r], 
-      lat = morphometry$latitude, 
-      lon = morphometry$longitude, 
-      hypsos = hypsos, 
-      irr_thresh = c(0.0762, 0.6476), 
-      wtr_thresh = c(11,25),
-      cum_ba = cum_benthic_area)
-  }) %>% 
-    purrr::reduce(bind_rows) %>% 
-    mutate(date = site_data$DateTime) %>% # Add the date column
-    mutate(site_id = site_data$site_id) %>% # Add the site column
-    select(site_id, date, everything()) %>% # Move site and date columns first
-    readr::write_csv(path = target_name)
 }
 
 #' @title Calculate OHA, THA, and TOHA within table.

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -41,10 +41,10 @@ calculate_toha_per_lake <- function(target_name, site_data_fn, morphometry) {
         wtr_thresh = c(11,25),
         cum_ba = cum_benthic_area)
     }) %>% 
-      purrr::reduce(bind_rows) %>% 
       mutate(date = site_data$DateTime) %>% # Add the date column
       mutate(site_id = site_data$site_id) %>% # Add the site column
       select(site_id, date, everything()) %>% # Move site and date columns first
+      bind_rows() %>% 
       readr::write_csv(path = target_name)
   }
   

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -34,7 +34,8 @@ calculate_toha_per_lake <- function(target_name, site_data_fn, morphometry) {
   }) %>% 
     purrr::reduce(bind_rows) %>% 
     mutate(date = site_data$DateTime) %>% # Add the date column
-    select(date, everything()) %>% # Move it so it's first
+    mutate(site_id = site_data$site_id) %>% # Add the site column
+    select(site_id, date, everything()) %>% # Move site and date columns first
     readr::write_csv(path = target_name)
 }
 

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -41,10 +41,9 @@ calculate_toha_per_lake <- function(target_name, site_data_fn, morphometry) {
         wtr_thresh = c(11,25),
         cum_ba = cum_benthic_area)
     }) %>% 
-      mutate(date = site_data$DateTime) %>% # Add the date column
-      mutate(site_id = site_data$site_id) %>% # Add the site column
-      select(site_id, date, everything()) %>% # Move site and date columns first
       bind_rows() %>% 
+      mutate(date = site_data$DateTime, .before = 1) %>% # Add the date column first (need dplyr > 1.0.0)
+      mutate(site_id = site_data$site_id, .before = 1) %>% # Add the site column first (need dplyr > 1.0.0)
       readr::write_csv(path = target_name)
   }
   

--- a/2_process/src/create_obs_lake_task_plan.R
+++ b/2_process/src/create_obs_lake_task_plan.R
@@ -1,0 +1,125 @@
+
+do_obs_lake_tasks <- function(target_name, task_df_fn, irr_df_fn, k0_df_fn, ...){
+  
+  tasks <- tibble(task_filepath = names(yaml::yaml.load_file(task_df_fn))) %>% 
+    mutate(filename = basename(task_filepath)) %>% 
+    extract(filename, 'site_id', "split_obs_data_(.*).feather", remove = FALSE) %>% 
+    select(task_filepath, site_id) %>% 
+    filter(nchar(task_filepath) != 0) 
+  
+  irr_files <- tibble(filepath = names(yaml::yaml.load_file(irr_df_fn))) %>% 
+    extract(filepath, into = 'site_id', regex = "pb0_(.*)_irradiance.csv", remove = FALSE) %>% 
+    select(site_id, irr_filepath = filepath)
+  clarity_files <- tibble(filepath = names(yaml::yaml.load_file(k0_df_fn))) %>% 
+    extract(filepath, into = 'site_id', regex = "gam_(.*)_clarity.csv", remove = FALSE) %>% 
+    select(site_id, clarity_filepath = filepath)
+  
+  # Merge clarity and irr file names to use
+  tasks <- tasks %>% left_join(irr_files, by = 'site_id') %>% left_join(clarity_files, by = 'site_id')
+  
+  # ---- create task steps ---- #
+  
+  #' I'm doing this because each toha task is slow running
+  #' and if `morphometry` changes, we don't want to have to re-run all of them,
+  #' just the ones where _their_ morphometry changed. So we are subsetting first. 
+  split_morphometry <- scipiper::create_task_step(
+    step_name = 'split_morphometry',
+    target_name = function(task_name, ...){
+      sprintf("%s_morphometry", task_name)
+    },
+    command = function(task_name, ...){
+      task_filepath <- dplyr::filter(tasks, site_id == task_name) %>% 
+        pull(task_filepath)
+      sprintf("morphometry[[I('%s')]]", task_name)
+    } 
+  )
+  
+  apply_data_criteria <- scipiper::create_task_step(
+    step_name = 'apply_data_criteria',
+    target_name = function(task_name, ...){
+      sprintf("filtered_obs_data_%s", task_name)
+    },
+    command = function(task_name, ...){
+      task_filepath <- dplyr::filter(tasks, site_id == task_name) %>% pull(task_filepath)
+      sprintf("filter_observed_data('%s')", task_filepath)
+    } 
+  )
+  
+  reformat_obs_data <- scipiper::create_task_step(
+    step_name = 'reformat_obs_data',
+    target_name = function(task_name, ...){
+      sprintf("formatted_obs_data_%s", task_name)
+    },
+    command = function(steps, ...){
+      sprintf("reformat_observed_data(%s)", steps[["apply_data_criteria"]]$target_name)
+    } 
+  )
+  
+  join_temp_kd_i0 <- scipiper::create_task_step(
+    step_name = 'join_temp_kd_i0',
+    target_name = function(task_name, step_name, ...){
+      sprintf("2_process/tmp/munged_obs_data_%s.feather", task_name)
+    },
+    command = function(task_name, steps, ...){
+      irr_filepath <- dplyr::filter(tasks, site_id == task_name) %>% pull(irr_filepath)
+      clarity_filepath <- dplyr::filter(tasks, site_id == task_name) %>% pull(clarity_filepath)
+      psprintf("join_observed_data(",
+               "target_name = target_name,",
+               "obs_data = %s," = steps[["reformat_obs_data"]]$target_name, 
+               "irr_data_fn = '%s'," = irr_filepath, 
+               "k0_data_fn = '%s')" = clarity_filepath)
+    } 
+  )
+  
+  calculate_obs_toha <- scipiper::create_task_step(
+    step_name = 'calculate_obs_toha',
+    target_name = function(task_name, ...){
+      sprintf("2_process/tmp/obs_toha_%s.csv", task_name)
+    },
+    command = function(task_name, steps, ...){
+      psprintf("calculate_toha_per_lake(", 
+               "target_name = target_name,",
+               "site_data_fn = '%s'," = steps[["join_temp_kd_i0"]]$target_name,
+               "morphometry = `%s_morphometry`)" = task_name
+      )
+    } 
+  )
+  
+  # ---- combine into a task plan ---- #
+  
+  task_plan <- create_task_plan(
+    task_names = tasks$site_id,
+    task_steps = list(
+      split_morphometry, apply_data_criteria, reformat_obs_data,
+      join_temp_kd_i0, calculate_obs_toha),
+    final_steps = 'calculate_obs_toha',
+    add_complete = FALSE)
+  
+  # ---- combine into a task makefile ---- #
+  
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = '2_obs_lake_tasks.yml',
+    include = 'remake.yml',
+    sources = c(...),
+    packages = c("purrr", "dplyr", "mda.lakes", "feather", "rLakeAnalyzer", "readr"),
+    final_targets = c(target_name),
+    finalize_funs = c('combine_obs_toha'),
+    as_promises = TRUE,
+    tickquote_combinee_objects = TRUE)
+  
+  # ---- build the task makefile ---- #
+  
+  loop_tasks(
+    task_plan = task_plan,
+    task_makefile = '2_obs_lake_tasks.yml',
+    num_tries = 1)
+  
+}
+
+combine_obs_toha <- function(target_name, ...) {
+  # Read feather files and combine into single CSV
+  purrr::map(list(...), read_csv, col_types = cols()) %>% 
+    purrr::reduce(bind_rows) %>% 
+    write_csv(target_name)
+}

--- a/2_process/src/create_obs_lake_task_plan.R
+++ b/2_process/src/create_obs_lake_task_plan.R
@@ -123,6 +123,6 @@ do_obs_lake_tasks <- function(target_name, task_df_fn, irr_df_fn, k0_df_fn, ...)
 combine_obs_toha <- function(target_name, ...) {
   # Read feather files and combine into single CSV
   purrr::map(list(...), read_csv, col_types = cols()) %>% 
-    purrr::reduce(bind_rows) %>% 
+    bind_rows() %>% 
     write_csv(target_name)
 }

--- a/2_process/src/create_obs_lake_task_plan.R
+++ b/2_process/src/create_obs_lake_task_plan.R
@@ -51,7 +51,7 @@ do_obs_lake_tasks <- function(target_name, task_df_fn, irr_df_fn, k0_df_fn, ...)
       sprintf("formatted_obs_data_%s", task_name)
     },
     command = function(steps, ...){
-      sprintf("reformat_observed_data(%s)", steps[["apply_data_criteria"]]$target_name)
+      sprintf("reformat_observed_data(`%s`)", steps[["apply_data_criteria"]]$target_name)
     } 
   )
   
@@ -65,7 +65,7 @@ do_obs_lake_tasks <- function(target_name, task_df_fn, irr_df_fn, k0_df_fn, ...)
       clarity_filepath <- dplyr::filter(tasks, site_id == task_name) %>% pull(clarity_filepath)
       psprintf("join_observed_data(",
                "target_name = target_name,",
-               "obs_data = %s," = steps[["reformat_obs_data"]]$target_name, 
+               "obs_data = `%s`," = steps[["reformat_obs_data"]]$target_name, 
                "irr_data_fn = '%s'," = irr_filepath, 
                "k0_data_fn = '%s')" = clarity_filepath)
     } 

--- a/2_process/src/create_obs_lake_task_plan.R
+++ b/2_process/src/create_obs_lake_task_plan.R
@@ -14,8 +14,11 @@ do_obs_lake_tasks <- function(target_name, task_df_fn, irr_df_fn, k0_df_fn, ...)
     extract(filepath, into = 'site_id', regex = "gam_(.*)_clarity.csv", remove = FALSE) %>% 
     select(site_id, clarity_filepath = filepath)
   
-  # Merge clarity and irr file names to use
-  tasks <- tasks %>% left_join(irr_files, by = 'site_id') %>% left_join(clarity_files, by = 'site_id')
+  # Merge clarity and irr file names to use & remove sites that don't have both irr and kd
+  tasks <- tasks %>% 
+    left_join(irr_files, by = 'site_id') %>% 
+    left_join(clarity_files, by = 'site_id') %>%
+    filter(!is.na(irr_filepath) & !is.na(clarity_filepath))
   
   # ---- create task steps ---- #
   

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -1,0 +1,44 @@
+
+filter_observed_data <- function(obs_fn) {
+  
+  observed_dat <- read_feather(obs_fn)
+  
+  # Filter so that there is more than 1 temperature value 
+  # per date (more than one depth)
+  dates_to_keep <- observed_dat %>% 
+    group_by(date) %>%
+    summarize(count = n()) %>% 
+    filter(count > 1) %>% 
+    pull(date)
+  
+  observed_dat %>% 
+    filter(date %in% dates_to_keep)
+  
+}
+
+reformat_observed_data <- function(obs_data) {
+  
+  obs_data %>% 
+    # This is the date column name that `calculate_toha_per_lake` expects
+    rename(DateTime = date) %>% 
+    mutate(col_name = paste0("temp_", depth)) %>%  
+    arrange(depth) %>% 
+    # Reformat to be `temp_[depth]` as columns with one row per date
+    tidyr::pivot_wider(id_cols = c("site_id", "DateTime"), 
+                       names_from = col_name, 
+                       values_from = temp) 
+  
+}
+
+join_observed_data <- function(target_name, obs_data, irr_data_fn, k0_data_fn) {
+  
+  # Reformat to be `temp_[depth]` as columns with one row per date
+  obs_data %>% 
+    left_join(read_csv(irr_data_fn, col_types = cols()), by = c("DateTime" = "date"), progress = FALSE) %>%
+    rename(io = rad_0) %>% 
+    left_join(read_csv(k0_data_fn, col_types = cols()), by = c("DateTime" = "date"), progress = FALSE) %>% 
+    select(site_id, DateTime, io, kd, everything()) %>% 
+    write_feather(target_name)
+  
+}
+

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -10,6 +10,11 @@ munge_observed_data <- function(target_name, obs_data_fn, irr_data_fn, kd_data_f
 }
 
 filter_observed_data <- function(obs_data) {
+
+  # The modeled data's temperature values were in a column called
+  # `pred` and were character, but the observed data had a column
+  # called `temp`
+  if(!"temp" %in% names(obs_data)) obs_data$temp <- as.numeric(obs_data$pred)
   
   # Filter so that there is more than 1 temperature value 
   # per date (more than one depth)

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -19,6 +19,7 @@ filter_observed_data <- function(obs_data) {
   # Filter so that there is more than 1 temperature value 
   # per date (more than one depth)
   dates_to_keep <- obs_data %>% 
+    filter(!is.na(temp)) %>% 
     group_by(date) %>%
     summarize(count = n()) %>% 
     filter(count > 1) %>% 

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -1,6 +1,8 @@
 
 munge_observed_data <- function(target_name, obs_data_fn, irr_data_fn, kd_data_fn) {
   
+  options(dplyr.summarise.inform = FALSE) # new dplyr 1.0 messaging is annoying so turn it off
+  
   observed_dat <- read_feather(obs_data_fn) %>% 
     filter_observed_data() %>% 
     reformat_observed_data() %>% 

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -1,17 +1,25 @@
 
-filter_observed_data <- function(obs_fn) {
+munge_observed_data <- function(target_name, obs_data_fn, irr_data_fn, kd_data_fn) {
   
-  observed_dat <- read_feather(obs_fn)
+  observed_dat <- read_feather(obs_data_fn) %>% 
+    filter_observed_data() %>% 
+    reformat_observed_data() %>% 
+    join_observed_data(irr_data_fn, kd_data_fn) %>% 
+    write_feather(target_name)
+  
+}
+
+filter_observed_data <- function(obs_data) {
   
   # Filter so that there is more than 1 temperature value 
   # per date (more than one depth)
-  dates_to_keep <- observed_dat %>% 
+  dates_to_keep <- obs_data %>% 
     group_by(date) %>%
     summarize(count = n()) %>% 
     filter(count > 1) %>% 
     pull(date)
   
-  observed_dat %>% 
+  obs_data %>% 
     filter(date %in% dates_to_keep) %>% 
     # Discovered during `reformat_observed_data` that some sites did
     # not have unique combinations of date & depth which causes the
@@ -22,14 +30,14 @@ filter_observed_data <- function(obs_fn) {
     ungroup()
   
 }
-
+ 
 reformat_observed_data <- function(obs_data) {
   
   obs_data %>% 
     # This is the date column name that `calculate_toha_per_lake` expects
     rename(DateTime = date) %>% 
     mutate(col_name = paste0("temp_", depth)) %>%  
-    arrange(depth) %>% 
+    arrange(depth) %>%
     # Reformat to be `temp_[depth]` as columns with one row per date
     tidyr::pivot_wider(id_cols = c("site_id", "DateTime"), 
                        names_from = col_name, 
@@ -37,15 +45,13 @@ reformat_observed_data <- function(obs_data) {
   
 }
 
-join_observed_data <- function(target_name, obs_data, irr_data_fn, k0_data_fn) {
+join_observed_data <- function(obs_data, irr_data_fn, kd_data_fn) {
   
   # Reformat to be `temp_[depth]` as columns with one row per date
   obs_data %>% 
     left_join(read_csv(irr_data_fn, col_types = cols()), by = c("DateTime" = "date"), progress = FALSE) %>%
     rename(io = rad_0) %>% 
-    left_join(read_csv(k0_data_fn, col_types = cols()), by = c("DateTime" = "date"), progress = FALSE) %>% 
-    select(site_id, DateTime, io, kd, everything()) %>% 
-    write_feather(target_name)
+    left_join(read_csv(kd_data_fn, col_types = cols()), by = c("DateTime" = "date"), progress = FALSE) %>% 
+    select(site_id, DateTime, io, kd, everything())
   
 }
-

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -16,7 +16,7 @@ filter_observed_data <- function(obs_data) {
   # The modeled data's temperature values were in a column called
   # `pred` and were character, but the observed data had a column
   # called `temp`
-  if(!"temp" %in% names(obs_data)) obs_data$temp <- as.numeric(obs_data$pred)
+  if(!"temp" %in% names(obs_data)) obs_data$temp <- obs_data$pred
   
   # Filter so that there is more than 1 temperature value 
   # per date (more than one depth)

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -12,7 +12,14 @@ filter_observed_data <- function(obs_fn) {
     pull(date)
   
   observed_dat %>% 
-    filter(date %in% dates_to_keep)
+    filter(date %in% dates_to_keep) %>% 
+    # Discovered during `reformat_observed_data` that some sites did
+    # not have unique combinations of date & depth which causes the
+    # pivoted data to have lists instead of single values. To fix, I
+    # am averaging the temperature values if there are more than 1.
+    group_by(site_id, date, depth) %>% 
+    summarize(temp = mean(temp)) %>% 
+    ungroup()
   
 }
 

--- a/2_process/src/observed_data_helpers_prepare.R
+++ b/2_process/src/observed_data_helpers_prepare.R
@@ -11,7 +11,7 @@ unzip_and_split_observed_data <- function(target_name, obs_zipfile, split_file_p
       write_feather(data, split_fn)
       return(split_fn)
     }) %>% 
-    purrr::reduce(c)
+    unlist()
   
   scipiper::sc_indicate(target_name, data_file = local_filenames)
 }

--- a/2_process/src/observed_data_helpers_prepare.R
+++ b/2_process/src/observed_data_helpers_prepare.R
@@ -1,4 +1,4 @@
-split_observed_data <- function(target_name, obs_zipfile, split_file_prefix) {
+unzip_and_split_observed_data <- function(target_name, obs_zipfile, split_file_prefix) {
   
   # Unzip the file
   unzipped_obs_file <- unzip(zipfile = obs_zipfile, overwrite = TRUE, exdir = tempdir())
@@ -14,4 +14,16 @@ split_observed_data <- function(target_name, obs_zipfile, split_file_prefix) {
     purrr::reduce(c)
   
   scipiper::sc_indicate(target_name, data_file = local_filenames)
+}
+
+unzip_data <- function(target_name, data_file, out_dir) {
+  # Sometimes (as is the case with irradiance and clarity), the incoming
+  # file has multiple zip files that need to be unpacked and saved
+  unzipped_data_files <- lapply(
+    names(yaml::yaml.load_file(data_file))[1:2], 
+    unzip, 
+    overwrite = TRUE, exdir = out_dir) %>% 
+    unlist()
+  
+  scipiper::sc_indicate(target_name, data_file = unzipped_data_files)
 }

--- a/2_process/src/observed_data_helpers_prepare.R
+++ b/2_process/src/observed_data_helpers_prepare.R
@@ -4,7 +4,7 @@ unzip_and_split_observed_data <- function(target_name, obs_zipfile, split_file_p
   unzipped_obs_file <- unzip(zipfile = obs_zipfile, overwrite = TRUE, exdir = tempdir())
   
   # Read in the csv & split into a feather file per lake
-  local_filenames <- readr::read_csv(unzipped_obs_file, col_types = 'cDddc') %>% 
+  local_filenames <- readr::read_csv(unzipped_obs_file, col_types = cols()) %>% 
     split(.$site_id) %>% 
     purrr::map(function(data) {
       split_fn <- sprintf("%s_%s.feather", split_file_prefix, unique(data$site_id))

--- a/2_process/src/observed_data_helpers_prepare.R
+++ b/2_process/src/observed_data_helpers_prepare.R
@@ -7,7 +7,7 @@ unzip_and_split_observed_data <- function(target_name, obs_zipfile, split_file_p
   local_filenames <- readr::read_csv(unzipped_obs_file, col_types = 'cDddc') %>% 
     split(.$site_id) %>% 
     purrr::map(function(data) {
-      split_fn <- sprintf("2_process/tmp/%s_%s.feather", split_file_prefix, unique(data$site_id))
+      split_fn <- sprintf("%s_%s.feather", split_file_prefix, unique(data$site_id))
       write_feather(data, split_fn)
       return(split_fn)
     }) %>% 

--- a/2_process/src/observed_data_helpers_prepare.R
+++ b/2_process/src/observed_data_helpers_prepare.R
@@ -20,7 +20,7 @@ unzip_data <- function(target_name, data_file, out_dir) {
   # Sometimes (as is the case with irradiance and clarity), the incoming
   # file has multiple zip files that need to be unpacked and saved
   unzipped_data_files <- lapply(
-    names(yaml::yaml.load_file(data_file))[1:2], 
+    names(yaml::yaml.load_file(data_file)), 
     unzip, 
     overwrite = TRUE, exdir = out_dir) %>% 
     unlist()

--- a/2_process/src/split_observed_data.R
+++ b/2_process/src/split_observed_data.R
@@ -1,0 +1,17 @@
+split_observed_data <- function(target_name, obs_zipfile, split_file_prefix) {
+  
+  # Unzip the file
+  unzipped_obs_file <- unzip(zipfile = obs_zipfile, overwrite = TRUE, exdir = tempdir())
+  
+  # Read in the csv & split into a feather file per lake
+  local_filenames <- readr::read_csv(unzipped_obs_file, col_types = 'cDddc') %>% 
+    split(.$site_id) %>% 
+    purrr::map(function(data) {
+      split_fn <- sprintf("2_process/tmp/%s_%s.feather", split_file_prefix, unique(data$site_id))
+      write_feather(data, split_fn)
+      return(split_fn)
+    }) %>% 
+    purrr::reduce(c)
+  
+  scipiper::sc_indicate(target_name, data_file = local_filenames)
+}


### PR DESCRIPTION
This is the first pass at adding observed data to the TOHA pipeline. This downloads a single CSV file (in SB as a zip file) with 877 lakes in total, munges/filters/etc temperature data for each individual lake, calculates TOHA for each individual lake, and then combines all of the TOHA results into a single output: `2_process/out/combined_obs_toha.csv`. Running `scmake("2_process/out/combined_obs_toha.csv")` calculates TOHA for all sites with observed data (after filtering out days that don't meet certain criteria & getting rid of sites that are missing kd & I_0) and currently takes 11 minutes.

Things to still be determined:

1. What are the criteria that we want to use to determine if we should calculate TOHA for a given day for a given site? Currently, implemented a basic count - at least 2 depths of data per day. I know that we probably want to get a bit more specific on those criteria. @jread-usgs you left ideas in https://github.com/USGS-R/lake-temperature-out/issues/16#issuecomment-622091236, but I'd like to talk through them to make sure I understand.
1. ~A current issue comes from https://github.com/USGS-R/lake-temperature-out/commit/3b994deeeba9b5121092a3374a628e46608f0d53 where there were a lot of sites did not have irradiation and clarity files available. Filtering out those that didn't have both irradiation and clarity data took our number of lakes from 877 to 110 😬. More investigation into why these sites don't have those files is needed. I haven't determined if they also were missing for PGDL and PB0, but I think we would have noticed if only 110 made it through.~ [please see silly mistake fixed here](https://github.com/USGS-R/lake-temperature-out/pull/27/commits/2eea43c00ccd02d4bcd611f7afc8d58fc6d95964)

This is for #16 
