### PR TITLE
Thermal metrics - additional metrics

### DIFF
--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -61,7 +61,7 @@ targets:
   3_summarize/out/annual_metrics_pgdl.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = test_files2,
+      site_files = pgdl_site_files,
       ice_files = ice_files,
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')
@@ -71,7 +71,7 @@ targets:
   3_summarize/out/annual_metrics_pb0.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = test_files,
+      site_files = pb0_site_files,
       ice_files = ice_files,
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -59,4 +59,5 @@ targets:
     command: calculate_annual_metrics(
       target_name,
       site_files = site_files,
-      ice_files = ice_files)
+      ice_files = ice_files,
+      morphometry)

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -10,6 +10,7 @@ sources:
   - 3_summarize/src/calculate_total_benthic_area.R
   - 2_process/src/calculate_toha.R # Has the benthic area fxn & resample_hypso
   - 3_summarize/src/annual_thermal_metrics.R
+  - 3_summarize/src/annual_thermal_metric_tasks.R
 
 targets:
   3_summarize:
@@ -58,17 +59,19 @@ targets:
   pgdl_site_files:
     command: get_filenames_from_ind("2_process/out/2_pgdl_grp_tasks_completed.yml")
   3_summarize/out/annual_metrics_pgdl.csv:
-    command: calculate_annual_metrics(
-      target_name,
-      site_files = pgdl_site_files,
+    command: do_annual_metrics_multi_lake(
+      final_target = target_name,
+      site_files = test_files2,
       ice_files = ice_files,
-      morphometry)
+      '2_process/src/calculate_toha.R',
+      '3_summarize/src/annual_thermal_metrics.R')
   
   pb0_site_files:
     command: get_filenames_from_ind("2_process/out/2_process_grp_tasks_completed.yml")
   3_summarize/out/annual_metrics_pb0.csv:
-    command: calculate_annual_metrics(
-      target_name,
-      site_files = pb0_site_files,
+    command: do_annual_metrics_multi_lake(
+      final_target = target_name,
+      site_files = test_files,
       ice_files = ice_files,
-      morphometry)
+      '2_process/src/calculate_toha.R',
+      '3_summarize/src/annual_thermal_metrics.R')

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -8,7 +8,7 @@ packages:
 sources:
   - 3_summarize/src/combine_files_to_zip.R
   - 3_summarize/src/calculate_total_benthic_area.R
-  - 2_process/src/calculate_toha.R # Has the benthic area fxn
+  - 2_process/src/calculate_toha.R # Has the benthic area fxn & resample_hypso
   - 3_summarize/src/annual_thermal_metrics.R
 
 targets:
@@ -18,6 +18,7 @@ targets:
       - 3_summarize/out/3_summarize_zip_pgdl_toha.yml
       - 3_summarize/out/total_benthic_areas.csv
       - 3_summarize/out/annual_metrics_pgdl.csv
+      - 3_summarize/out/annual_metrics_pb0.csv
 
   ### Zip up lake toha files by lake group ###
   
@@ -51,13 +52,23 @@ targets:
   # Based these additional metrics on the ones included in a previous lake modeling
   # data release (see https://www.sciencebase.gov/catalog/item/57d9e887e4b090824ffb1098)
   
-  site_files:
-    command: get_filenames_from_ind("2_process/out/2_pgdl_grp_tasks_completed.yml")
   ice_files:
     command: get_filenames_from_ind("2_process/out/iceflags_unzipped.yml")
+  
+  pgdl_site_files:
+    command: get_filenames_from_ind("2_process/out/2_pgdl_grp_tasks_completed.yml")
   3_summarize/out/annual_metrics_pgdl.csv:
     command: calculate_annual_metrics(
       target_name,
-      site_files = site_files,
+      site_files = pgdl_site_files,
+      ice_files = ice_files,
+      morphometry)
+  
+  pb0_site_files:
+    command: get_filenames_from_ind("2_process/out/2_process_grp_tasks_completed.yml")
+  3_summarize/out/annual_metrics_pb0.csv:
+    command: calculate_annual_metrics(
+      target_name,
+      site_files = pb0_site_files,
       ice_files = ice_files,
       morphometry)

--- a/3_summarize/src/annual_thermal_metric_tasks.R
+++ b/3_summarize/src/annual_thermal_metric_tasks.R
@@ -1,0 +1,76 @@
+
+do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, ...) {
+  
+  # Define task table rows
+  tasks <- tibble(wtr_filename = site_files) %>% 
+    extract(wtr_filename, c('prefix','site_id','suffix'), "(pb0|pball|pgdl)_data_(.*)(.feather)", remove = FALSE) %>% 
+    left_join(extract(tibble(ice_filename = ice_files), ice_filename, c('site_id'), "pb0_(.*)_ice_flags.csv", remove = FALSE), by = "site_id") %>% 
+    select(site_id, wtr_filename, ice_filename, prefix)
+  
+  model_type <- pull(tasks, prefix) %>% unique()
+  
+  # Define task table columns
+  
+  # I'm doing this because each toha task is slow running
+  # and if `morphometry` changes, we don't want to have to re-run all of them,
+  # just the ones where _their_ morphometry changed. So we are subsetting first. 
+  split_morphometry <- scipiper::create_task_step(
+    step_name = 'split_morphometry',
+    target_name = function(task_name, step_name, ...){
+      
+      sprintf("%s_morphometry", task_name)
+    },
+    command = function(task_name, ...){
+      sprintf("morphometry[[I('%s')]]", task_name)
+    } 
+  )
+  
+  calc_annual_metrics <- create_task_step(
+    step_name = 'calc_annual_metrics',
+    target_name = function(task_name, step_name, ...) {
+      sprintf("%s_annual_thermal_metrics", task_name)
+    },
+    command = function(..., task_name, steps) {
+      task_info <- filter(tasks, site_id == task_name)
+      psprintf("calculate_annual_metrics_per_lake(", 
+               "site_id = I('%s')," = task_name,
+               "site_file = '%s'," = task_info$wtr_filename,
+               "ice_file = '%s'," = task_info$ice_filename,
+               "morphometry = %s)" = steps[["split_morphometry"]]$target_name
+      )
+    }
+  )
+  
+  # Create the task plan
+  task_plan <- create_task_plan(
+    task_names = tasks$site_id,
+    task_steps = list(split_morphometry, calc_annual_metrics),
+    final_steps = c('calc_annual_metrics'),
+    add_complete = FALSE)
+  
+  # Create the task remakefile
+  task_makefile <- sprintf('3_summarize_%s_metric_tasks.yml', model_type)
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = task_makefile,
+    include = 'remake.yml',
+    sources = c(...),
+    packages = c('tidyverse', 'purrr', 'readr'),
+    final_targets = final_target,
+    finalize_funs = 'combine_thermal_metrics',
+    as_promises = TRUE,
+    tickquote_combinee_objects = TRUE)
+  
+  # Build the tasks
+  loop_tasks(task_plan = task_plan,
+             task_makefile = task_makefile,
+             num_tries = 1)
+  
+  # Now return the file name of the final the combined CSV
+  return(remake::fetch(sprintf("%s_promise", basename(final_target)), remake_file=task_makefile))
+  
+}
+
+combine_thermal_metrics <- function(target_name, ...) {
+  purrr::reduce(list(...), bind_rows) %>% readr::write_csv(target_name)
+}

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -320,7 +320,7 @@ get_last_years_data <- function(this_year, dat_all) {
 
 #' @description Cumulative sum of degrees >base degrees for entire year
 calc_gdd <- function(wtr, base = 0) {
-  sum(wtr[wtr > base])
+  sum(wtr[wtr > base], na.rm = TRUE)
 }
 
 # Uses 0.1 m from the bottom as the "bottom"

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -43,15 +43,15 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         winter_dur_0_4 = winter_dur_0_4(date, wtr, depth, prev_yr_data=get_last_years_data(unique(year), data_ready)),
         coef_var_30_60 = coef_var_30_60(wtr, depth, ice),
         # coef_var_0_30 = coef_var_0_30(),
+        # Metrics that deal with the stratified period
         stratification_onset_yday = stratification_onset_yday(date, in_stratified_period),
         stratification_duration = stratification_duration(date, in_stratified_period),
         sthermo_depth_mean = sthermo_depth_mean(date, depth, wtr, in_stratified_period),
+        bottom_temp_at_strat = bottom_temp_at_strat(date, wtr_bot_daily, unique(year), stratification_onset_yday),
         
         gdd_wtr_0c = calc_gdd(wtr, 0),
         gdd_wtr_5c = calc_gdd(wtr, 5),
         gdd_wtr_10c = calc_gdd(wtr, 10),
-        
-        bottom_temp_at_strat = bottom_temp_at_strat(date, wtr_bot_daily, unique(year), stratification_onset_yday),
         # schmidt_daily_annual_sum = schmidt_daily_annual_sum(),
         
         # The following section of metrics return a data.frame per summarize command and

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -358,10 +358,11 @@ find_wtr_at_depth <- function(wtr, depth, depth_to_find) {
 #' `force_warm` flag to either count only warm stratified periods
 #' or count both warm and cool stratified periods.
 is_stratified <- function(wtr_surface, wtr_bottom, force_warm = FALSE) {
-  # difference between top and bottom > 1 deg
+  # If either top or bottom wtr is missing, then we can't determine if it is stratified.
+  if(is.na(wtr_surface) | is.na(wtr_bottom)) return(FALSE) 
   t_diff <- wtr_surface - wtr_bottom
   if(!force_warm) t_diff <- abs(t_diff) # Count both cold and warm periods
-  t_diff >= 1
+  t_diff >= 1 # Stratified means that the difference between top and bottom > 1 deg
 }
 
 is_in_longest_consective_chunk <- function(bool_vec) {

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -201,8 +201,10 @@ bottom_temp_at_strat <- function(date, wtr_bot, year, stratification_onset_yday)
 #' @description Sum of daily Schmidt Stability values for calendar year.
 schmidt_daily_annual_sum <- function(date, depth, wtr, ice_on_date, ice_off_date, hypso) {
   tibble(date, depth, wtr) %>% 
-    # Only use days with open water (no ice)
-    filter(date >= ice_off_date & date <= ice_on_date) %>%
+    # Only use days with open water (no ice) and handle situations
+    # where one of the `ice_off` or `ice_on` dates is NA
+    {if(!is.na(ice_off_date)) filter(., date >= ice_off_date) else . } %>%
+    {if(!is.na(ice_on_date)) filter(., date <= ice_on_date) else . } %>%
     group_by(date) %>%
     summarize(daily_ss = rLakeAnalyzer::schmidt.stability(wtr, depth, hypso$areas, hypso$depths), .groups = "keep") %>%
     pull(daily_ss) %>%

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -317,7 +317,9 @@ calc_first_day_above_temp <- function(date, wtr_surf, temperatures) {
   wtr_surf_unique <- unique_day_data(date, wtr_surf)
   
   date_above_df <- lapply(temperatures, function(temp) {
-    date_unique[wtr_surf_unique >= temp] %>% head(1) %>% format("%j") %>% as.numeric()
+    first_day_above_temp <- date_unique[wtr_surf_unique >= temp] %>% head(1) %>% format("%j") %>% as.numeric()
+    if(length(first_day_above_temp) == 0) first_day_above_temp <- NA # Return NA if that temp was never exceeded
+    return(first_day_above_temp)
   }) %>% data.frame()
   names(date_above_df) <- sprintf("date_over_%s", temperatures)
   

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -45,8 +45,8 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         ice_off_date = get_ice_onoff(date, ice, peak_temp_dt, "off"),
         
         winter_dur_0_4 = winter_dur_0_4(date, wtr, depth, prev_yr_data=get_last_years_data(unique(year), data_ready)),
-        coef_var_30_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(30,60)),
-        coef_var_0_30 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(0,30)),
+        coef_var_30_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(31,60)),
+        coef_var_0_30 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(1,30)),
         
         # Metrics that deal with the stratified period
         stratification_onset_yday = stratification_onset_yday(date, in_stratified_period),

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -33,9 +33,10 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files, morphom
       ungroup() %>% 
       select(-year)
     
+    site_id_for_matching <- gsub("\\}", "\\\\}", gsub("\\{", "\\\\{", site_id)) # Need to escape the special chars for grepl
     data_ready_with_flags <- data_ready %>% 
       # Read and join ice flags for this site
-      left_join(read_csv(ice_files[grepl(site_id, ice_files)]), by = "date") %>% 
+      left_join(read_csv(ice_files[grepl(site_id_for_matching, ice_files)], col_types = cols()), by = "date") %>% 
       arrange(date, depth) %>% # Data was coming in correct, but just making sure 
       # Add flag to say if the day is stratified or not. Doing this here because it will be used
       # by multiple annual metrics below.

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -344,7 +344,16 @@ is_stratified <- function(wtr_surface, wtr_bottom, force_warm = FALSE) {
 }
 
 is_in_longest_consective_chunk <- function(bool_vec) {
-  with(rle(bool_vec), rep(lengths == max(lengths[values]) & values, lengths))
+  # Added check for duplicates to prevent counting more than one period
+  # if they are equal in length.
+  continuous_sections <- rle(bool_vec)
+  
+  # Identify any periods that are duplicated, so that we can pick the first one
+  continuous_sections$is_duplicated <- NA
+  continuous_sections$is_duplicated[continuous_sections$values] <- duplicated(continuous_sections$lengths[continuous_sections$values])
+  continuous_sections$is_duplicated[!continuous_sections$values] <- FALSE
+  
+  with(continuous_sections, rep(!is_duplicated & lengths == max(lengths[values]) & values, lengths))
 }
 
 get_ice_onoff <- function(date, ice, peak_temp_dt, on_or_off) {

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -66,36 +66,36 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files, morphom
         gdd_wtr_5c = calc_gdd(date, wtr_surf_daily, 5),
         gdd_wtr_10c = calc_gdd(date, wtr_surf_daily, 10),
         schmidt_daily_annual_sum = schmidt_daily_annual_sum(date, depth, wtr, ice_on_date, ice_off_date, hypso),
-        
+
         # The following section of metrics return a data.frame per summarize command and
         #   are unpacked into their real columns after using `unpack`
-        
+
         mean_surf_jas = calc_monthly_summary_stat(date, wtr_surf_daily, "surf", "mean", month_nums_to_grp = 7:9),
         max_surf_jas = calc_monthly_summary_stat(date, wtr_surf_daily, "surf", "max", month_nums_to_grp = 7:9),
         mean_bot_jas = calc_monthly_summary_stat(date, wtr_bot_daily, "bot", "mean", month_nums_to_grp = 7:9),
         max_bot_jas = calc_monthly_summary_stat(date, wtr_bot_daily, "bot", "max", month_nums_to_grp = 7:9),
-        
+
         mean_surf_mon = calc_monthly_summary_stat(date, wtr_surf_daily, "surf", "mean"),
         max_surf_mon = calc_monthly_summary_stat(date, wtr_surf_daily, "surf", "max"),
         mean_bot_mon = calc_monthly_summary_stat(date, wtr_bot_daily, "bot", "mean"),
         max_bot_mon = calc_monthly_summary_stat(date, wtr_bot_daily, "bot", "max"),
-        
+
         # Hansen metrics
         # See https://github.com/USGS-R/necsc-lake-modeling/blob/d37377ea422b9be324e8bd203fc6eecc36966401/data/habitat_metrics_table_GH.csv
 
         days_height_vol_in_range = calc_days_height_vol_within_range(date, depth, wtr, hypso,
                                                                      temp_low = c(12, 10.6, 18.2, 18, 19.3, 19, 20.6, 20, 22, 23, 25, 26.2, 26, 26, 28, 28, 29, 30),
                                                                      temp_high = c(28, 11.2, 28.2, 22, 23.3, 23, 23.2, 30, 23, 31, 29, 32, 28, 30, 29, 32, 100, 31)),
-        
+
         spring_days_in_10.5_15.5 = spring_days_incub(date, wtr_surf_daily, c(10.5, 15.5)),
         post_ice_warm_rate = post_ice_warm_rate(date, wtr_surf_daily, ice_off_date),
         date_over_temps = calc_first_day_above_temp(date, wtr_surf_daily, temperatures = c(8.9, 16.7, 18, 21)), # Returns a df and needs to be unpacked below
-        
+
         .groups = "keep" # suppresses message about regrouping
       ) %>% 
       unpack(cols = c(mean_surf_mon, max_surf_mon, mean_bot_mon, max_bot_mon,
                       mean_surf_jas, max_surf_jas, mean_bot_jas, max_bot_jas,
-                      date_over_temps, days_height_vol_in_range)) %>% 
+                      date_over_temps, days_height_vol_in_range)) %>%
       ungroup()
     
     message(sprintf("Completed annual metrics for %s/%s in %s min", 
@@ -469,9 +469,11 @@ unique_day <- function(date) {
   # Unique day dates only
   i_unique_day <- which(!duplicated(date))
   return(date[i_unique_day])
+}
 
 # Needs `resample_hypso` from source("2_process/src/calculate_toha.R")
 calc_volume <- function(Z1, Z2, hypso) {
   A1 <- resample_hypso(hypso, Z1)$areas
   A2 <- resample_hypso(hypso, Z2)$areas
   abs(A2-A1)*(Z2-Z1)/3
+}

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -15,7 +15,7 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
       summarize(wtr_surf_daily = wtr[depth == 0],
                 wtr_bot_daily = find_wtr_at_depth(wtr, depth, calc_lake_bottom(depth)),
                 .groups = "keep") %>% 
-      mutate(stratified = is_stratified(wtr_surf_daily, wtr_bot_daily)) %>% 
+      mutate(stratified = is_stratified(wtr_surf_daily, wtr_bot_daily, force_warm = TRUE)) %>% 
       ungroup() %>% 
       # Add year back in because it is dropped in `group_by` above
       mutate(year = as.numeric(format(date, "%Y"))) %>% 
@@ -335,9 +335,11 @@ find_wtr_at_depth <- function(wtr, depth, depth_to_find) {
   approx(depth, wtr, depth_to_find)$y
 }
 
-is_stratified <- function(wtr_surface, wtr_bottom) {
+is_stratified <- function(wtr_surface, wtr_bottom, force_warm = FALSE) {
   # difference between top and bottom > 1 deg
-  abs(wtr_surface - wtr_bottom) > 1
+  t_diff <- wtr_surface - wtr_bottom
+  if(!force_warm) t_diff <- abs(t_diff) # Count both cold and warm periods
+  t_diff >= 1
 }
 
 is_in_longest_consective_chunk <- function(bool_vec) {

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -36,6 +36,10 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
       group_by(site_id, year) %>% 
       summarize(
         
+        # Maximum observed surface temperature & corresponding date
+        peak_temp = max(wtr_surf_daily, na.rm = TRUE),
+        peak_temp_dt = date[which.max(wtr_surf_daily)],
+        
         winter_dur_0_4 = winter_dur_0_4(date, wtr, depth, prev_yr_data=get_last_years_data(unique(year), data_ready)),
         coef_var_30_60 = coef_var_30_60(wtr, depth, ice),
         # coef_var_0_30 = coef_var_0_30(),
@@ -43,7 +47,6 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         stratification_duration = stratification_duration(date, in_stratified_period),
         sthermo_depth_mean = sthermo_depth_mean(date, depth, wtr, in_stratified_period),
         
-        peak_temp = peak_temp(wtr_surf_daily),
         gdd_wtr_0c = calc_gdd(wtr, 0),
         gdd_wtr_5c = calc_gdd(wtr, 5),
         gdd_wtr_10c = calc_gdd(wtr, 10),
@@ -151,11 +154,6 @@ sthermo_depth_mean <- function(date, depth, wtr, stratified_period) {
     summarize(daily_thermocline = rLakeAnalyzer::thermo.depth(wtr, depth), .groups = "keep") %>% 
     pull(daily_thermocline) %>% 
     mean(na.rm = TRUE)
-}
-
-#' @description Maximum observed surface temperature
-peak_temp <- function(wtr_surf) {
-  max(wtr_surf, na.rm = TRUE)
 }
 
 #' @description water temperature 0.1m from lake bottom on day of 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -158,8 +158,9 @@ coef_var <- function(date, wtr_surf, ice_off_date, day_post_range) {
 #' @description Julian date at which stratification sets up (longest stratified period)
 stratification_onset_yday <- function(date, stratified_period) {
   # https://stackoverflow.com/questions/37447114/find-the-longest-continuous-chunk-of-true-in-a-boolean-vector
-  i_strat_start <- head(which(stratified_period), 1)
-  as.numeric(format(date[i_strat_start], "%j"))
+  i_unique_day <- which(!duplicated(date))
+  i_strat_start <- head(which(stratified_period[i_unique_day]), 1)
+  as.numeric(format(date[i_unique_day][i_strat_start], "%j"))
 }
 
 #' @description Duration of stratified period

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -142,7 +142,9 @@ winter_dur_0_4 <- function(this_yr_date, this_yr_wtr, this_yr_depth, prev_yr_dat
    
 }
 
-#' @description Coefficient of Variation of surface temperature from a range of days post ice off.
+#' @description Coefficient of Variation of surface temperature from a range of days 
+#' post ice off. This calculation is the same as Winslow 2017, but that one wasn't 
+#' named intuitively (`coef_var_0_30` instead of `coef_var_1_30`)
 coef_var <- function(date, wtr_surf, ice_off_date, day_post_range) {
   
   # Need one dat & wtr_surf per day
@@ -336,6 +338,10 @@ find_wtr_at_depth <- function(wtr, depth, depth_to_find) {
   approx(depth, wtr, depth_to_find)$y
 }
 
+#' @description Determines if a day is stratified by comparing the
+#' difference between the surface and bottom temperatures. Uses the
+#' `force_warm` flag to either count only warm stratified periods
+#' or count both warm and cool stratified periods.
 is_stratified <- function(wtr_surface, wtr_bottom, force_warm = FALSE) {
   # difference between top and bottom > 1 deg
   t_diff <- wtr_surface - wtr_bottom

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -56,7 +56,7 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         gdd_wtr_0c = calc_gdd(wtr, 0),
         gdd_wtr_5c = calc_gdd(wtr, 5),
         gdd_wtr_10c = calc_gdd(wtr, 10),
-        # schmidt_daily_annual_sum = schmidt_daily_annual_sum(),
+        # TODO schmidt_daily_annual_sum = schmidt_daily_annual_sum(),
         
         # The following section of metrics return a data.frame per summarize command and
         #   are unpacked into their real columns after using `unpack`
@@ -75,7 +75,7 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         # See https://github.com/USGS-R/necsc-lake-modeling/blob/d37377ea422b9be324e8bd203fc6eecc36966401/data/habitat_metrics_table_GH.csv
         
         # I think these need hypso, like the schmidt one, so waiting til last to do that
-        # vol_[X] #TODO: calc vol too
+        # TODO vol_[X] need to calc vol too
         days_height_vol_in_range = calc_days_height_vol_within_range(date, depth, wtr, 
                                                                      temp_low = c(12, 10.6, 18.2, 18, 19.3, 19, 20.6, 20, 22, 23, 25, 26.2, 26, 26, 28, 28, 29, 30), 
                                                                      temp_high = c(28, 11.2, 28.2, 22, 23.3, 23, 23.2, 30, 23, 31, 29, 32, 28, 30, 29, 32, 100, 31)),

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -53,10 +53,10 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         stratification_duration = stratification_duration(date, in_stratified_period),
         sthermo_depth_mean = sthermo_depth_mean(date, depth, wtr, in_stratified_period),
         bottom_temp_at_strat = bottom_temp_at_strat(date, wtr_bot_daily, unique(year), stratification_onset_yday),
-        
-        gdd_wtr_0c = calc_gdd(wtr, 0),
-        gdd_wtr_5c = calc_gdd(wtr, 5),
-        gdd_wtr_10c = calc_gdd(wtr, 10),
+
+        gdd_wtr_0c = calc_gdd(date, wtr_surf_daily, 0),
+        gdd_wtr_5c = calc_gdd(date, wtr_surf_daily, 5),
+        gdd_wtr_10c = calc_gdd(date, wtr_surf_daily, 10),
         # TODO schmidt_daily_annual_sum = schmidt_daily_annual_sum(),
         
         # The following section of metrics return a data.frame per summarize command and
@@ -319,8 +319,9 @@ get_last_years_data <- function(this_year, dat_all) {
 
 
 #' @description Cumulative sum of degrees >base degrees for entire year
-calc_gdd <- function(wtr, base = 0) {
-  sum(wtr[wtr > base], na.rm = TRUE)
+calc_gdd <- function(date, wtr, base = 0) {
+  wtr_unique <- unique_day_data(date, wtr)
+  sum(wtr_unique[wtr_unique > base], na.rm=TRUE)
 }
 
 # Uses 0.1 m from the bottom as the "bottom"

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -2,6 +2,7 @@
 calculate_annual_metrics <- function(target_name, site_files, ice_files) {
   
   purrr::map(site_files, function(fn) {
+    start_tm <- Sys.time()
     
     data_ready <- read_feather(fn) %>% 
       select(site_id, date = DateTime, starts_with("temp_")) %>% 
@@ -91,7 +92,9 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
                       date_over_temps, days_height_vol_in_range)) %>% 
       ungroup()
     
-    message(sprintf("Completed annual metrics for %s/%s", which(site_files == fn), length(site_files)))
+    message(sprintf("Completed annual metrics for %s/%s in %s min", 
+                    which(site_files == fn), length(site_files), 
+                    round(as.numeric(Sys.time() - start_tm, units = "mins"), 2)))
     
     return(annual_metrics)
   }) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -320,8 +320,8 @@ get_last_years_data <- function(this_year, dat_all) {
 
 #' @description Cumulative sum of degrees >base degrees for entire year
 calc_gdd <- function(date, wtr, base = 0) {
-  wtr_unique <- unique_day_data(date, wtr)
-  sum(wtr_unique[wtr_unique > base], na.rm=TRUE)
+  wtr_diff <- unique_day_data(date, wtr) - base
+  sum(wtr_diff[wtr_diff > 0], na.rm=TRUE)
 }
 
 # Uses 0.1 m from the bottom as the "bottom"

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -45,8 +45,8 @@ calculate_annual_metrics <- function(target_name, site_files, ice_files) {
         ice_off_date = get_ice_onoff(date, ice, peak_temp_dt, "off"),
         
         winter_dur_0_4 = winter_dur_0_4(date, wtr, depth, prev_yr_data=get_last_years_data(unique(year), data_ready)),
-        coef_var_30_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(31,60)),
-        coef_var_0_30 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(1,30)),
+        coef_var_31_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(31,60)),
+        coef_var_1_30 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(1,30)),
         
         # Metrics that deal with the stratified period
         stratification_onset_yday = stratification_onset_yday(date, in_stratified_period),


### PR DESCRIPTION
Added the rest of the metrics from the 2017 data release + 6 from the [Hansen metrics list](https://github.com/USGS-R/necsc-lake-modeling/blob/d37377ea422b9be324e8bd203fc6eecc36966401/data/habitat_metrics_table_GH.csv#L61) (days_[X], height_[X], spring_days_in_10.5_15.5, post_ice_warm_rate, dateOver[X]). ~Still missing the ones that need hypso - `vol_[X]` from the Hansen list and `schmidt_daily_annual_sum` from the original data release. ~ Added those on 10/22

Currently takes ~ 5 minutes for one site. While that isn't great, it does give us ~108 metrics for each year. Can consider speeding it up (I create some tibbles inside of `summarize` which isn't great) but I like the readability for now. Will look into that after I get this past some initial validation checks.

Currently validating the original 2017 data release metrics, but ~there are [9 metrics that need a little more work](https://github.com/USGS-R/lake-temperature-out/issues/31#issuecomment-703844477) before we can call this good.~ Only one metric is still not working. 

Also, one outstanding question is whether we can expect wtr NAs. I don't think so if we are doing this for PGDL and PB0 only, but if we use the observed data, I need to be able to deal with NAs in wtr/depth.