### PR TITLE
Thermal metrics - Add final Hansen metrics + one bug fix

### DIFF
--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -361,7 +361,9 @@ calc_metalimnion_derivatives <- function(date, depth, wtr, stratified_period, st
                 mean_hyp_vol = mean(hyp_vol, na.rm = TRUE)) %>% 
       mutate(mean_epi_hypo_ratio = mean_epi_vol / mean_hyp_vol)
   } else {
-    return(NA) # If the stratified period is < 30 days, return NA
+    # If the stratified period is < 30 days, return NA
+    return(tibble(SmetaTopD_mean = NA, SmetaBotD_mean = NA, mean_epi_vol = NA, 
+                  mean_hyp_vol = NA, mean_epi_hypo_ratio = NA)) 
   }
   
 }

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -90,6 +90,8 @@ calculate_annual_metrics_per_lake <- function(site_id, site_file, ice_file, morp
       post_ice_warm_rate = post_ice_warm_rate(date, wtr_surf_daily, ice_off_date),
       date_over_temps = calc_first_day_above_temp(date, wtr_surf_daily, temperatures = c(8.9, 16.7, 18, 21)), # Returns a df and needs to be unpacked below
 
+      simulation_length_days = calc_n_days(date, wtr),
+      
       .groups = "keep" # suppresses message about regrouping
     ) %>% 
     unpack(cols = c(mean_surf_mon, max_surf_mon, mean_bot_mon, max_bot_mon,
@@ -326,6 +328,15 @@ calc_first_day_above_temp <- function(date, wtr_surf, temperatures) {
   names(date_above_df) <- sprintf("date_over_%s", temperatures)
   
   return(date_above_df)
+}
+
+calc_n_days <- function(date, wtr) {
+  # count days that have at least one non-NA value
+  tibble(date, wtr) %>% 
+    group_by(date) %>% 
+    summarize(data_exists = any(!is.na(wtr))) %>% 
+    pull(data_exists) %>% 
+    sum() 
 }
 
 ## Helper functions for the above

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -390,7 +390,14 @@ calc_lake_bottom <- function(depth) {
 # Doesn't consider dates at all
 # Assumes linear interpolation for depth-wtr relationship
 find_wtr_at_depth <- function(wtr, depth, depth_to_find) {
-  approx(depth, wtr, depth_to_find)$y
+  if(length(na.omit(wtr)) > 1) {
+    # Can only linearly interpolate if there are at least 2 values to use
+    # Otherwise, this throws an error. Will still return NA if the depth value
+    # to find is outside of the values available.
+    approx(depth, wtr, depth_to_find)$y
+  } else {
+    return(NA)
+  }
 }
 
 #' @description Determines if a day is stratified by comparing the

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -91,16 +91,12 @@ calculate_annual_metrics_per_lake <- function(site_id, site_file, ice_file, morp
       date_over_temps = calc_first_day_above_temp(date, wtr_surf_daily, temperatures = c(8.9, 16.7, 18, 21)), # Returns a df and needs to be unpacked below
       
       simulation_length_days = calc_n_days(date, wtr),
-
-      # This doesn't change per timestep because the water levels aren't time varying, so just
-      # using hypso which means they should be the same for every year. Returns mean and sum vols
-      volume_X_m_3 = calc_volume_X_m_3(hypso),
       
       .groups = "keep" # suppresses message about regrouping
     ) %>% 
     unpack(cols = c(mean_surf_mon, max_surf_mon, mean_bot_mon, max_bot_mon,
                     mean_surf_jas, max_surf_jas, mean_bot_jas, max_bot_jas,
-                    date_over_temps, days_height_vol_in_range, volume_X_m_3)) %>%
+                    date_over_temps, days_height_vol_in_range)) %>%
     ungroup()
   
   message(sprintf("Completed annual metrics for %s in %s min", site_id, 
@@ -340,12 +336,6 @@ calc_n_days <- function(date, wtr) {
     summarize(data_exists = any(!is.na(wtr))) %>% 
     pull(data_exists) %>% 
     sum() 
-}
-
-calc_volume_X_m_3 <- function(hypso) {
-  slice_vols <- calc_volume(head(hypso$depths, -1), tail(hypso$depths, -1), hypso)
-  tibble(volume_mean_m_3 = mean(slice_vols, na.rm = TRUE), 
-         volume_sum_m_3 = sum(slice_vols, na.rm = TRUE))
 }
 
 ## Helper functions for the above

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -9,10 +9,7 @@ calculate_annual_metrics_per_lake <- function(site_id, site_file, ice_file, morp
     mutate(depth = as.numeric(gsub("temp_", "", depth))) %>% 
     mutate(year = as.numeric(format(date, "%Y")))
   
-  if(nrow(data_ready) == 0) {
-    message(sprintf("Skipping annual metrics for %s because there is no wtr data", site_id))
-    return(data.frame())
-  }
+  stopifnot(nrow(data_ready) > 0) # There should be data for each site file
   
   # Get hypso for this site
   hypso <- data.frame(H = morphometry$H, A = morphometry$A) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -9,6 +9,11 @@ calculate_annual_metrics_per_lake <- function(site_id, site_file, ice_file, morp
     mutate(depth = as.numeric(gsub("temp_", "", depth))) %>% 
     mutate(year = as.numeric(format(date, "%Y")))
   
+  if(nrow(data_ready) == 0) {
+    message(sprintf("Skipping annual metrics for %s because there is no wtr data", site_id))
+    return(data.frame())
+  }
+  
   # Get hypso for this site
   hypso <- data.frame(H = morphometry$H, A = morphometry$A) %>% 
     mutate(depths = max(H) - H, areas = A) %>% 


### PR DESCRIPTION
# Bugs squashed

- [X] ~handle situations where the site data is empty (`nhdhr_120018569` was the culprit)~ actually, didn't end up keeping that change. Decided that when site data is empty, it should fail since these model outputs should all have data
- [X] handle situations where `approx` cannot be used because there are not enough non-NA wtr values for a given day (this happened in `nhdhr_120018012` when running with PB0 wtr data for `1996-02-08`)

# Final metrics added

Added the final metrics and tested that the code works for a site with < 30 stratified days (`nhd_1096982`) and one with more than 30 (`nhd_10595598`). These lake numbers are from the original data release, not our most recent model outputs. I also successfully tested both a PGDL site (`nhdhr_91594761`) and a PB0 site (`nhdhr_{820B0DD5-51F5-4C99-AB26-F63B5612E309}`).

- sthermo_depth_mean (this is fixed now!)
- SmetaTopD_mean
- SmetaBotD_mean
- mean_epi_hypo_ratio
- mean_epi_vol
- mean_hyp_vol
- simulation_length_days
- ~volume_mean_m_3~ did not add since this application does not have changing water levels and this would be a static number per lake
- ~volume_sum_m_3_day~ did not add since this application does not have changing water levels and this would be a static number per lake

# Outstanding Questions:

- Should we only be calculating `bottom_temp_at_strat` if there are at least 30 days in the stratified period?
- Should `is_stratified` specifically remove any date with an ice flag? It doesn't right now, but maybe it just happens to work for the lakes I have tested. 