### PR TITLE
change so that file is read in as object and then used by each core

### DIFF
--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -3,6 +3,7 @@ target_default: 3_summarize
 packages:
   - dplyr
   - feather
+  - readr
   - tidyr
 
 sources:
@@ -52,6 +53,9 @@ targets:
   
   # Based these additional metrics on the ones included in a previous lake modeling
   # data release (see https://www.sciencebase.gov/catalog/item/57d9e887e4b090824ffb1098)
+
+  temp_ranges:
+    command: read_tsv("3_summarize/in/temp_ranges_for_metrics.txt")
   
   ice_files:
     command: get_filenames_from_ind("2_process/out/iceflags_unzipped.yml")
@@ -63,7 +67,6 @@ targets:
       final_target = target_name,
       site_files = pgdl_site_files,
       ice_files = ice_files,
-      temp_range_file = '3_summarize/in/temp_ranges_for_metrics.txt', 
       n_cores = 1,
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')
@@ -75,7 +78,6 @@ targets:
       final_target = target_name,
       site_files = pb0_site_files,
       ice_files = ice_files,
-      temp_range_file = '3_summarize/in/temp_ranges_for_metrics.txt',
       n_cores = 40,
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')

--- a/3_summarize/src/annual_thermal_metric_tasks.R
+++ b/3_summarize/src/annual_thermal_metric_tasks.R
@@ -1,12 +1,11 @@
 
-do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, temp_range_file, n_cores, ...) {
+do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_cores, ...) {
   
   # Define task table rows
   tasks <- tibble(wtr_filename = site_files) %>% 
     extract(wtr_filename, c('prefix','site_id','suffix'), "(pb0|pball|pgdl)_data_(.*)(.feather)", remove = FALSE) %>% 
     left_join(extract(tibble(ice_filename = ice_files), ice_filename, c('site_id'), "pb0_(.*)_ice_flags.csv", remove = FALSE), by = "site_id") %>% 
-    mutate(temp_range_file = temp_range_file) %>% # Same for each task
-    select(site_id, wtr_filename, ice_filename, temp_range_file, prefix)
+    select(site_id, wtr_filename, ice_filename, prefix)
   
   model_type <- pull(tasks, prefix) %>% unique()
   
@@ -38,7 +37,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, te
                "site_id = I('%s')," = task_name,
                "site_file = '%s'," = task_info$wtr_filename,
                "ice_file = '%s'," = task_info$ice_filename,
-               "temp_range_file = '%s'," = task_info$temp_range_file,
+               "temp_ranges = temp_ranges,",
                "morphometry = `%s`," = steps[["split_morphometry"]]$target_name,
                # Doesn't actually print to console with `loop_tasks` but let's you see if you are troubleshooting individual files
                "verbose = I(TRUE))" 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -1,5 +1,5 @@
 
-calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_file, temp_range_file, morphometry, verbose = FALSE) {
+calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_file, temp_ranges, morphometry, verbose = FALSE) {
   
   start_tm <- Sys.time()
     
@@ -34,8 +34,6 @@ calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_
     mutate(in_stratified_period = is_in_longest_consective_chunk(stratified)) %>% 
     ungroup() %>% 
     select(-year)
-  
-  temp_ranges <- read_tsv(temp_range_file)
   
   data_ready_with_flags <- data_ready %>% 
     arrange(date, depth) %>% # Data was coming in correct, but just making sure 


### PR DESCRIPTION
Read in the TSV of temp ranges first as an object. Then each task in `loop_tasks` can use that rather then each task attempting to read in that TSV.