### PR TITLE
Add glm2 pb0 and pball to pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Rlib_3_6/
 
 # scipiper-specific files and folders
 */tmp/*
+*/tmp_glm2/*
 !1_fetch/tmp/EMPTY
 !2_process/tmp/EMPTY
 !3_summarize/tmp/EMPTY

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -24,6 +24,8 @@ targets:
   sb_dl_date:
    command: c(I("2020-04-29"))
   
+  ##-- Download files for mntoha data release --##
+  
   toha_sbid:
     command: c(I("5e5d0bb9e4b01d50924f2b36"))
   clarity_ice_sbid:
@@ -82,6 +84,15 @@ targets:
       keyword = I("ice_flags"), 
       dest_folder = I("1_fetch/tmp"),
       dummy = sb_dl_date)
+  
+  ##-- Download files for multi-state glm2 data release --##
+  
+  preds_sbid:
+    command: c(I("5db819a8e4b0b0c58b5a4c45"))
+  ice_sbid:
+    command: c(I("5db81996e4b0b0c58b5a4c43"))
+  # Delete this. No clarity data but are there irradiance data?
+  # TODO: Pick up here on Monday.
   
   ##-- Download files for error estimation --##
   

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -11,12 +11,20 @@ sources:
 targets:
   1_fetch:
     depends:
+    # mntoha data release targets
       - 1_fetch/out/lake_metadata.csv
       - 1_fetch/out/config.json
       - 1_fetch/out/irradiance_downloaded.yml
       - 1_fetch/out/pb0_temp_pred_downloaded.yml
       - 1_fetch/out/clarity_downloaded.yml
       - 1_fetch/out/iceflags_downloaded.yml
+      - 1_fetch/out/glm2_lake_metadata.csv
+    # multi-state glm2 data release targets
+      - 1_fetch/out/glm2_pb0_config.json
+      - 1_fetch/out/glm2_pball_config.json
+      - 1_fetch/out/glm2_pb0_pball_temp_pred_downloaded.yml
+      - 1_fetch/out/glm2_iceflags_downloaded.yml
+    # error estimation temp data targets
       - 1_fetch/out/temperature_observations.zip
       - 1_fetch/out/pb0_matched_to_observations.zip
       - 1_fetch/out/pgdl_matched_to_observations.zip
@@ -87,12 +95,53 @@ targets:
   
   ##-- Download files for multi-state glm2 data release --##
   
-  preds_sbid:
-    command: c(I("5db819a8e4b0b0c58b5a4c45"))
-  ice_sbid:
-    command: c(I("5db81996e4b0b0c58b5a4c43"))
-  # Delete this. No clarity data but are there irradiance data?
-  # TODO: Pick up here on Monday.
+  1_fetch/out/glm2_lake_metadata.csv:
+    command: download_sb_single_file(
+      target_name = target_name,
+      sb_id = I("5db8194be4b0b0c58b5a4c3c"), 
+      sb_filename = I('01_lake_metadata.csv'),
+      dummy = sb_dl_date)
+  
+  glm2_config_sbid:
+    command: c(I("5db81967e4b0b0c58b5a4c3f"))
+  
+  1_fetch/out/glm2_pb0_config.json:
+    command: download_sb_single_file(
+      target_name = target_name,
+      sb_id = glm2_config_sbid, 
+      sb_filename = I('pb0_config.json'),
+      dummy = sb_dl_date)
+  
+  1_fetch/out/glm2_pball_config.json:
+    command: download_sb_single_file(
+      target_name = target_name,
+      sb_id = glm2_config_sbid, 
+      sb_filename = I('pball_config.json'),
+      dummy = sb_dl_date)
+  
+  # Add prefix to multi-file downloads in case previous 
+  #  pb0 ones (from mntoha release) are named the same
+  glm2_preds_prefix:
+    command: c(I("glm2"))
+  
+  # This contains PB0 GLM2 and PBALL data in each zip.
+  1_fetch/out/glm2_pb0_pball_temp_pred_downloaded.yml:
+    command: download_sb_files(
+      target_name = target_name, 
+      sb_id = I("5db819a8e4b0b0c58b5a4c45"), 
+      keyword = I("predictions"), 
+      dest_folder = I("1_fetch/tmp"),
+      dummy = sb_dl_date,
+      dest_file_prefix = glm2_preds_prefix)
+  
+  1_fetch/out/glm2_iceflags_downloaded.yml:
+    command: download_sb_files(
+      target_name = target_name, 
+      sb_id = I("5db81996e4b0b0c58b5a4c43"), 
+      keyword = I("ice_flags"), 
+      dest_folder = I("1_fetch/tmp"),
+      dummy = sb_dl_date,
+      dest_file_prefix = glm2_preds_prefix)
   
   ##-- Download files for error estimation --##
   

--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -121,8 +121,6 @@ targets:
   
   # Add prefix to multi-file downloads in case previous 
   #  pb0 ones (from mntoha release) are named the same
-  glm2_preds_prefix:
-    command: c(I("glm2"))
   
   # This contains PB0 GLM2 and PBALL data in each zip.
   1_fetch/out/glm2_pb0_pball_temp_pred_downloaded.yml:
@@ -132,7 +130,7 @@ targets:
       keyword = I("predictions"), 
       dest_folder = I("1_fetch/tmp"),
       dummy = sb_dl_date,
-      dest_file_prefix = glm2_preds_prefix)
+      dest_file_prefix = I("glm2"))
   
   1_fetch/out/glm2_iceflags_downloaded.yml:
     command: download_sb_files(
@@ -141,7 +139,7 @@ targets:
       keyword = I("ice_flags"), 
       dest_folder = I("1_fetch/tmp"),
       dummy = sb_dl_date,
-      dest_file_prefix = glm2_preds_prefix)
+      dest_file_prefix = I("glm2"))
   
   ##-- Download files for error estimation --##
   

--- a/1_fetch/src/fetch_sb_item_files.R
+++ b/1_fetch/src/fetch_sb_item_files.R
@@ -1,16 +1,22 @@
 
 #' use `dummy` to trigger rebuilds. Using the date, as a light reminder of when it was changed
  
-download_sb_files <- function(target_name, sb_id, keyword, dest_folder, dummy) {
+download_sb_files <- function(target_name, sb_id, keyword, dest_folder, dummy, dest_file_prefix = NULL) {
   
   sb_check_login()
   
   sb_filenames <- list_sb_files(sb_id, keyword)
   
+  if(!is.null(dest_file_prefix)) {
+    dest_filenames <- sprintf("%s_%s", dest_file_prefix, sb_filenames)
+  } else {
+    dest_filenames <- sb_filenames
+  }
+  
   local_filenames <- item_file_download(
     sb_id, 
     names = sb_filenames, 
-    destinations = file.path(dest_folder, sb_filenames),
+    destinations = file.path(dest_folder, dest_filenames),
     overwrite_file = TRUE)
   
   scipiper::sc_indicate(target_name, data_file = local_filenames)

--- a/2_process.yml
+++ b/2_process.yml
@@ -18,10 +18,18 @@ sources:
 targets:
   2_process:
     depends:
+    # mntoha data release targets
       - 2_process/out/2_pb0_lake_tasks.ind
       - 2_process/out/2_pgdl_lake_tasks.ind
-      - 2_process/out/combined_obs_toha.csv
       - 2_process/out/iceflags_unzipped.yml
+    # multi-state glm2 data release targets
+      - 2_process/out/2_glm2_pb0_unzipped.yml
+      - 2_process/out/2_glm2_pball_unzipped.yml
+      - 2_process/out/glm2_iceflags_unzipped.yml
+    # error estimation temp data targets
+      - 2_process/out/combined_obs_toha.csv
+  
+##-- MN TOHA Data Release --##
   
   sb_group_info:
     command: read_csv("1_fetch/out/lake_metadata.csv")
@@ -76,7 +84,59 @@ targets:
       '2_process/src/do_lake_toha_tasks.R')
     depends:
       - morphometry
+
+  ### Prepare ice flags for use in 3_summary ###
+  
+  2_process/out/iceflags_unzipped.yml:
+    command: unzip_data(
+      target_name = target_name,
+      data_file = "1_fetch/out/iceflags_downloaded.yml",
+      out_dir = I("2_process/tmp"))
+  
+##-- Multi-state GLM2 Data Release --##
+  
+  glm2_sb_group_info:
+    command: read_csv("1_fetch/out/glm2_lake_metadata.csv")
+  glm2_sb_group_ids:
+    command: get_group_ids(glm2_sb_group_info)
+    
+  glm2_pb0_morphometry:
+    command: extract_morphometry("1_fetch/out/glm2_pb0_config.json")  
+  glm2_pball_morphometry:
+    command: extract_morphometry("1_fetch/out/glm2_pball_config.json")
+  
+  ### Munge data by each lake group ###
+  
+  # Unzip each lake group file, then subset into a yml for pb0 and one for pball
+  
+  2_process/out/2_glm2_pb0_pball_unzipped.yml:
+    command: unzip_data(
+      target_name = target_name,
+      data_file = "1_fetch/out/glm2_pb0_pball_temp_pred_downloaded.yml",
+      out_dir = I("2_process/tmp_glm2"))
       
+  2_process/out/2_glm2_pb0_unzipped.yml:
+    command: subset_yml(
+      target_name = target_name,
+      full_yml = "2_process/out/2_glm2_pb0_pball_unzipped.yml",
+      regex = I("pb0_"))
+  
+  2_process/out/2_glm2_pball_unzipped.yml:
+    command: subset_yml(
+      target_name = target_name,
+      full_yml = "2_process/out/2_glm2_pb0_pball_unzipped.yml",
+      regex = I("pball_"))
+  
+  # Prepare ice flags for use in 3_summary. Contains pb0 and pball 
+  # ice flags, but those are handled in 3_summarize with the regex.
+  2_process/out/glm2_iceflags_unzipped.yml:
+    command: unzip_data(
+      target_name = target_name,
+      data_file = "1_fetch/out/glm2_iceflags_downloaded.yml",
+      out_dir = I("2_process/tmp"))
+      
+##-- Munge files for error estimation --##
+
   ### Calculate TOHA for each lake using observed temperature data ###
   
   ## Prepare irradiance and clarity data for merging with observed temp by unzipping individual lake files ##
@@ -154,11 +214,3 @@ targets:
       "2_process/src/do_obs_lakes_tasks.R")
     depends:
       - morphometry
-
-  ## Prepare ice flags for use in 3_summary
-  
-  2_process/out/iceflags_unzipped.yml:
-    command: unzip_data(
-      target_name = target_name,
-      data_file = "1_fetch/out/iceflags_downloaded.yml",
-      out_dir = I("2_process/tmp"))

--- a/2_process/src/do_lake_toha_tasks.R
+++ b/2_process/src/do_lake_toha_tasks.R
@@ -62,7 +62,7 @@ do_lake_toha_tasks <- function(final_target, task_df_fn, n_cores, ...) {
   
   ##-- Create the task remakefile --##
   
-  task_makefile <- sprintf('2_%s_lake_tasks.yml', model_prefix)
+  task_makefile <- sprintf('2_%s_lake_tasks.yml', model_type)
   create_task_makefile( 
     task_plan=task_plan,
     makefile=task_makefile,

--- a/2_process/src/observed_data_helpers_prepare.R
+++ b/2_process/src/observed_data_helpers_prepare.R
@@ -15,15 +15,3 @@ unzip_and_split_observed_data <- function(target_name, obs_zipfile, split_file_p
   
   scipiper::sc_indicate(target_name, data_file = local_filenames)
 }
-
-unzip_data <- function(target_name, data_file, out_dir) {
-  # Sometimes (as is the case with irradiance and clarity), the incoming
-  # file has multiple zip files that need to be unpacked and saved
-  unzipped_data_files <- lapply(
-    names(yaml::yaml.load_file(data_file)), 
-    unzip, 
-    overwrite = TRUE, exdir = out_dir) %>% 
-    unlist()
-  
-  scipiper::sc_indicate(target_name, data_file = unzipped_data_files)
-}

--- a/2_process/src/process_helpers.R
+++ b/2_process/src/process_helpers.R
@@ -14,3 +14,19 @@ extract_morphometry <- function(config_fn) {
   return(morphometry_out)
 }
 
+unzip_data <- function(target_name, data_file, out_dir) {
+  # Sometimes (as is the case with irradiance and clarity), the incoming
+  # file has multiple zip files that need to be unpacked and saved
+  unzipped_data_files <- lapply(
+    names(yaml::yaml.load_file(data_file)), 
+    unzip, 
+    overwrite = TRUE, exdir = out_dir) %>% 
+    unlist()
+  
+  scipiper::sc_indicate(target_name, data_file = unzipped_data_files)
+}
+
+subset_yml <- function(target_name, full_yml, regex) {
+  full_yml_list <- yaml::yaml.load_file(full_yml)
+  yaml::write_yaml(full_yml_list[grep(regex, names(full_yml_list))], target_name)
+}

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -16,11 +16,17 @@ sources:
 targets:
   3_summarize:
     depends:
+    # mntoha data release targets
       - 3_summarize/out/3_summarize_zip_pb0_toha.yml
       - 3_summarize/out/3_summarize_zip_pgdl_toha.yml
       - 3_summarize/out/total_benthic_areas.csv
       - 3_summarize/out/annual_metrics_pgdl.csv
       - 3_summarize/out/annual_metrics_pb0.csv
+    # multi-state glm2 data release targets
+      - 3_summarize/out/annual_metrics_glm2pb0.csv
+      - 3_summarize/out/annual_metrics_glm2pball.csv
+
+##-- MN TOHA Data Release --##
 
   ### Zip up lake toha files by lake group ###
   
@@ -81,6 +87,49 @@ targets:
       site_files = pb0_site_files,
       ice_files = ice_files,
       n_cores = 40,
+      '2_process/src/calculate_toha.R',
+      '3_summarize/src/annual_thermal_metrics.R')
+    depends:
+      - temp_ranges
+
+##-- Multi-state GLM2 Data Release --##
+
+  glm2_ice_files:
+    command: get_filenames_from_ind("2_process/out/glm2_iceflags_unzipped.yml")
+  
+  glm2_pb0_files:
+    command: get_filenames_from_ind("2_process/out/2_glm2_pb0_unzipped.yml")
+  test_i:
+    command: c(1,2)
+  test_files:
+    command: glm2_pb0_files[test_i]
+  3_summarize/out/annual_metrics_glm2pb0.csv:
+    command: do_annual_metrics_multi_lake(
+      final_target = target_name,
+      site_files = test_files,
+      ice_files = glm2_ice_files,
+      n_cores = 40,
+      site_file_regex = I("(pb0)_(.*)_temperatures(.csv)"),
+      ice_file_regex = I("pb0_(.*)_ice_flag.csv"),
+      morph_prefix = I("glm2_pb0_"), 
+      tmpdir_suffix = I("_glm2"),
+      '2_process/src/calculate_toha.R',
+      '3_summarize/src/annual_thermal_metrics.R')
+    depends:
+      - temp_ranges
+      
+  glm2_pball_files:
+    command: get_filenames_from_ind("2_process/out/2_glm2_pball_unzipped.yml")
+  3_summarize/out/annual_metrics_glm2pball.csv:
+    command: do_annual_metrics_multi_lake(
+      final_target = target_name,
+      site_files = glm2_pball_files,
+      ice_files = glm2_ice_files,
+      n_cores = 40,
+      site_file_regex = I("(pball)_(.*)_temperatures(.csv)"),
+      ice_file_regex = I("pball_(.*)_ice_flag.csv"),
+      morph_prefix = I("glm2_pball_"), 
+      tmpdir_suffix = I("_glm2"),
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')
     depends:

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -107,14 +107,13 @@ targets:
       site_files = glm2_pb0_files,
       ice_files = glm2_ice_files,
       n_cores = 40,
+      morphometry = glm2_pb0_morphometry,
+      temp_ranges = temp_ranges,
       site_file_regex = I("(pb0)_(.*)_temperatures(.csv)"),
       ice_file_regex = I("pb0_(.*)_ice_flag.csv"),
-      morph_prefix = I("glm2_pb0_"), 
       tmpdir_suffix = I("_glm2"),
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')
-    depends:
-      - temp_ranges
       
   glm2_pball_files:
     command: get_filenames_from_ind("2_process/out/2_glm2_pball_unzipped.yml")

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -99,14 +99,10 @@ targets:
   
   glm2_pb0_files:
     command: get_filenames_from_ind("2_process/out/2_glm2_pb0_unzipped.yml")
-  test_i:
-    command: c(1,2)
-  test_files:
-    command: glm2_pb0_files[test_i]
   3_summarize/out/annual_metrics_glm2pb0.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = test_files,
+      site_files = glm2_pb0_files,
       ice_files = glm2_ice_files,
       n_cores = 40,
       site_file_regex = I("(pb0)_(.*)_temperatures(.csv)"),

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -113,7 +113,8 @@ targets:
       ice_file_regex = I("pb0_(.*)_ice_flag.csv"),
       tmpdir_suffix = I("_glm2"),
       '2_process/src/calculate_toha.R',
-      '3_summarize/src/annual_thermal_metrics.R')
+      '3_summarize/src/annual_thermal_metrics.R',
+      '3_summarize/src/do_annual_thermal_metric_tasks.R')
       
   glm2_pball_files:
     command: get_filenames_from_ind("2_process/out/2_glm2_pball_unzipped.yml")

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -60,8 +60,10 @@ targets:
   # Based these additional metrics on the ones included in a previous lake modeling
   # data release (see https://www.sciencebase.gov/catalog/item/57d9e887e4b090824ffb1098)
 
-  temp_ranges:
+  temp_range_info:
     command: read_tsv("3_summarize/in/temp_ranges_for_metrics.txt")
+  temp_ranges:
+    command: select(temp_range_info, I('Temp_Low'), I('Temp_High'))
   
   ice_files:
     command: get_filenames_from_ind("2_process/out/iceflags_unzipped.yml")

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -65,29 +65,22 @@ targets:
   temp_ranges:
     command: select(temp_range_info, I('Temp_Low'), I('Temp_High'))
   
-  ice_files:
-    command: get_filenames_from_ind("2_process/out/iceflags_unzipped.yml")
-  
-  pgdl_site_files:
-    command: get_filenames_from_ind("2_process/out/2_pgdl_grp_tasks_completed.yml")
   3_summarize/out/annual_metrics_pgdl.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = pgdl_site_files,
-      ice_files = ice_files,
+      site_file_yml = "2_process/out/2_pgdl_grp_tasks_completed.yml",
+      ice_file_yml = "2_process/out/iceflags_unzipped.yml",
       n_cores = 40,
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')
     depends:
       - temp_ranges
   
-  pb0_site_files:
-    command: get_filenames_from_ind("2_process/out/2_pb0_grp_tasks_completed.yml")
   3_summarize/out/annual_metrics_pb0.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = pb0_site_files,
-      ice_files = ice_files,
+      site_file_yml = "2_process/out/2_pb0_grp_tasks_completed.yml",
+      ice_file_yml = "2_process/out/iceflags_unzipped.yml",
       n_cores = 40,
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R')
@@ -96,16 +89,11 @@ targets:
 
 ##-- Multi-state GLM2 Data Release --##
 
-  glm2_ice_files:
-    command: get_filenames_from_ind("2_process/out/glm2_iceflags_unzipped.yml")
-  
-  glm2_pb0_files:
-    command: get_filenames_from_ind("2_process/out/2_glm2_pb0_unzipped.yml")
   3_summarize/out/annual_metrics_glm2pb0.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = glm2_pb0_files,
-      ice_files = glm2_ice_files,
+      site_file_yml = "2_process/out/2_glm2_pb0_unzipped.yml",
+      ice_file_yml = "2_process/out/glm2_iceflags_unzipped.yml",
       n_cores = 40,
       morphometry = glm2_pb0_morphometry,
       temp_ranges = temp_ranges,
@@ -115,14 +103,12 @@ targets:
       '2_process/src/calculate_toha.R',
       '3_summarize/src/annual_thermal_metrics.R',
       '3_summarize/src/do_annual_thermal_metric_tasks.R')
-      
-  glm2_pball_files:
-    command: get_filenames_from_ind("2_process/out/2_glm2_pball_unzipped.yml")
+  
   3_summarize/out/annual_metrics_glm2pball.csv:
     command: do_annual_metrics_multi_lake(
       final_target = target_name,
-      site_files = glm2_pball_files,
-      ice_files = glm2_ice_files,
+      site_file_yml = "2_process/out/2_glm2_pball_unzipped.yml",
+      ice_file_yml = "2_process/out/glm2_iceflags_unzipped.yml",
       n_cores = 40,
       site_file_regex = I("(pball)_(.*)_temperatures(.csv)"),
       ice_file_regex = I("pball_(.*)_ice_flag.csv"),

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -1,5 +1,5 @@
 
-calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_file, temp_ranges, morphometry_ind, verbose = FALSE) {
+calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_file, temp_ranges_file, morphometry_ind, verbose = FALSE) {
   
   start_tm <- Sys.time()
   
@@ -28,6 +28,9 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
     mutate(depths = max(H) - H, areas = A) %>% 
     arrange(depths) %>% 
     select(depths, areas)
+  
+  # Read in temp ranges to use
+  temp_ranges <- readRDS(temp_ranges_file)
   
   data_stratification_ice <- data_ready %>% 
     group_by(date) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -23,7 +23,7 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
   stopifnot(nrow(data_ready) > 0) # There should be data for each site file
   
   # Get hypso for this site
-  morphometry <- as_data_file(morphometry_ind)
+  morphometry <- readRDS(as_data_file(morphometry_ind))
   hypso <- data.frame(H = morphometry$H, A = morphometry$A) %>% 
     mutate(depths = max(H) - H, areas = A) %>% 
     arrange(depths) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -2,9 +2,19 @@
 calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_file, temp_ranges, morphometry, verbose = FALSE) {
   
   start_tm <- Sys.time()
-    
-  data_ready <- read_feather(site_file) %>% 
-    select(site_id, date = DateTime, starts_with("temp_")) %>% 
+  
+  if(tools::file_ext(site_file) == "feather") {
+    wtr_data <- read_feather(site_file) %>% 
+      select(site_id, date = DateTime, starts_with("temp_"))
+  } else if(tools::file_ext(site_file) == "csv") {
+    wtr_data <- read_csv(site_file) %>% 
+      mutate(site_id = site_id) %>% 
+      select(site_id, date, starts_with("temp_"))
+  } else {
+    stop(sprintf("Error with %s: file type not supported", site_file))
+  }
+  
+  data_ready <- wtr_data %>% 
     pivot_longer(cols = starts_with("temp_"), names_to = "depth", values_to = "wtr") %>% 
     mutate(depth = as.numeric(gsub("temp_", "", depth))) %>% 
     mutate(year = as.numeric(format(date, "%Y"))) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -23,7 +23,7 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
   stopifnot(nrow(data_ready) > 0) # There should be data for each site file
   
   # Get hypso for this site
-  morphometry <- sc_retrieve(morphometry_ind)
+  morphometry <- as_data_file(morphometry_ind)
   hypso <- data.frame(H = morphometry$H, A = morphometry$A) %>% 
     mutate(depths = max(H) - H, areas = A) %>% 
     arrange(depths) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -1,5 +1,5 @@
 
-calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_file, temp_ranges, morphometry, verbose = FALSE) {
+calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_file, temp_ranges, morphometry_ind, verbose = FALSE) {
   
   start_tm <- Sys.time()
   
@@ -23,6 +23,7 @@ calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_
   stopifnot(nrow(data_ready) > 0) # There should be data for each site file
   
   # Get hypso for this site
+  morphometry <- sc_retrieve(morphometry_ind)
   hypso <- data.frame(H = morphometry$H, A = morphometry$A) %>% 
     mutate(depths = max(H) - H, areas = A) %>% 
     arrange(depths) %>% 
@@ -116,7 +117,7 @@ calculate_annual_metrics_per_lake <- function(out_file, site_id, site_file, ice_
                     round(as.numeric(Sys.time() - start_tm, units = "mins"), 2)))
   }
   
-  saveRDS(annual_metrics, out_file)
+  saveRDS(annual_metrics, as_data_file(out_ind))
 
 }
 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -117,7 +117,9 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
                     round(as.numeric(Sys.time() - start_tm, units = "mins"), 2)))
   }
   
-  saveRDS(annual_metrics, as_data_file(out_ind))
+  data_file <- as_data_file(out_ind)
+  saveRDS(annual_metrics, data_file)
+  sc_indicate(ind_file = out_ind, data_file = data_file)
 
 }
 

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -1,7 +1,7 @@
 
-do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_cores, 
+do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_cores, ...,
                                          site_file_regex = NULL, ice_file_regex = NULL,
-                                         morph_prefix = "", tmpdir_suffix = "", ...) {
+                                         morph_prefix = "", tmpdir_suffix = "") {
   
   # Each node on a Yeti normal partition has a max of 20 cores; nodes on Yeti UV partition do not have that same limit
   if(n_cores > 20) message("If using a node on the Yeti normal partition, you need to decrease n_cores to 20 or less")

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -1,6 +1,9 @@
 
-do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_cores, morphometry, temp_ranges, ...,
+do_annual_metrics_multi_lake <- function(final_target, site_file_yml, ice_file_yml, n_cores, morphometry, temp_ranges, ...,
                                          site_file_regex = NULL, ice_file_regex = NULL, tmpdir_suffix = "") {
+  
+  site_files <- get_filenames_from_ind(site_file_yml)
+  ice_files <- get_filenames_from_ind(ice_file_yml)
   
   # Each node on a Yeti normal partition has a max of 20 cores; nodes on Yeti UV partition do not have that same limit
   if(n_cores > 20) message("If using a node on the Yeti normal partition, you need to decrease n_cores to 20 or less")

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -30,7 +30,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_
     step_name = 'split_morphometry',
     target_name = function(task_name, step_name, ...){
       
-      sprintf("%s_morphometry.rds.ind", task_name)
+      sprintf("3_summarize/tmp%s/%s_morphometry.rds.ind", tmpdir_suffix, task_name)
     },
     command = function(task_name, ...){
       sprintf("split_and_save_morphometry(target_name, %smorphometry, I('%s'))", morph_prefix, task_name)
@@ -62,8 +62,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_
     task_names = tasks$site_id,
     task_steps = list(split_morphometry, calc_annual_metrics),
     final_steps = c('calc_annual_metrics'),
-    ind_dir = c('3_summarize/log'),
-    add_complete = TRUE)
+    add_complete = FALSE)
   
   # Create the task remakefile
   task_makefile <- sprintf('3_summarize_%s_metric_tasks.yml', model_type)
@@ -100,5 +99,7 @@ combine_thermal_metrics <- function(target_name, ...) {
 }
 
 split_and_save_morphometry <- function(out_ind, morphometry, site_id) {
-  saveRDS(morphometry[[site_id]], as_data_file(out_ind))
+  data_file <- as_data_file(out_ind)
+  saveRDS(morphometry[[site_id]], data_file)
+  sc_indicate(ind_file = out_ind, data_file = data_file)
 }

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -50,7 +50,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_
                "site_file = '%s'," = task_info$wtr_filename,
                "ice_file = '%s'," = task_info$ice_filename,
                "temp_ranges = temp_ranges,",
-               "morphometry_ind = `%s`," = steps[["split_morphometry"]]$target_name,
+               "morphometry_ind = '%s'," = steps[["split_morphometry"]]$target_name,
                # Doesn't actually print to console with `loop_tasks` but let's you see if you are troubleshooting individual files
                "verbose = I(TRUE))" 
       )

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -62,7 +62,8 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_
     task_names = tasks$site_id,
     task_steps = list(split_morphometry, calc_annual_metrics),
     final_steps = c('calc_annual_metrics'),
-    add_complete = FALSE)
+    ind_dir = c('3_summarize/log'),
+    add_complete = TRUE)
   
   # Create the task remakefile
   task_makefile <- sprintf('3_summarize_%s_metric_tasks.yml', model_type)

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -95,7 +95,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_
 }
 
 combine_thermal_metrics <- function(target_name, ...) {
-  purrr::map(list(...), function(ind) readRDS(sc_retrieve(ind))) %>% purrr::reduce(bind_rows) %>% readr::write_csv(target_name)
+  purrr::map(list(...), function(ind) readRDS(as_data_file(ind))) %>% purrr::reduce(bind_rows) %>% readr::write_csv(target_name)
 }
 
 split_and_save_morphometry <- function(out_ind, morphometry, site_id) {

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -33,7 +33,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_files, ice_files, n_
       sprintf("%s_morphometry.rds.ind", task_name)
     },
     command = function(task_name, ...){
-      sprintf("split_morphometry(target_name, %smorphometry, I('%s'))", morph_prefix, task_name)
+      sprintf("split_and_save_morphometry(target_name, %smorphometry, I('%s'))", morph_prefix, task_name)
     } 
   )
   
@@ -99,6 +99,6 @@ combine_thermal_metrics <- function(target_name, ...) {
   purrr::map(list(...), function(ind) readRDS(sc_retrieve(ind))) %>% purrr::reduce(bind_rows) %>% readr::write_csv(target_name)
 }
 
-split_morphometry <- function(out_ind, morphometry, site_id) {
+split_and_save_morphometry <- function(out_ind, morphometry, site_id) {
   saveRDS(morphometry[[site_id]], as_data_file(out_ind))
 }

--- a/README.md
+++ b/README.md
@@ -50,10 +50,22 @@ library(scipiper)
 sbtools::authenticate_sb('cidamanager')
 scmake('3_summarize/out/annual_metrics_pgdl.csv')
 ```
-but code will need to be modified so that you use loop tasks and also so you can specify the number of cores loop tasks is using...
 
-If the job fails or you are kicked off Yeti, no worries, as remake/scipiper will pick back up where you left off in the task table. 🎉
+Note that `3_summarize.yml` will need to be modified to take advantage of loop tasks by specifying the number of cores to use. If the job fails or you are kicked off Yeti, no worries, as remake/scipiper will pick back up where you left off in the task table. 🎉
 
+Lastly, the `glm2 pb0` runs have tons of lakes and were successfully run by NOT using an interactive R session. So, instead of starting R as it says in the steps above, add an R script called `run.R` that contains that following script and kick off at the command line by running `nohup Rscript run.R &`. The difference is that you can't use this method to log in to SB, so make sure `1_fetch` steps are complete first.
+
+```r
+# To kick this off, run the following in the command line instead of `R`
+# `nohup Rscript run.R &`
+
+message("Build with no login to SB")
+library(scipiper)
+
+message(sprintf("starting 3_summarize for glm2pb0 at %s", Sys.time()))
+scmake("3_summarize/out/annual_metrics_glm2pb0.csv")
+
+```
 
 ## Editing files on the cluster - Launching Jupyter Lab
 


### PR DESCRIPTION
This is for the multi-state GLM2 data release. This does not add the ability to get TOHA (there is no clarity or irradiance data for these), only the annual thermal metrics. Attempted to adapt as many existing functions as possible when implementing. The SB zipped files followed a slightly different pattern than the MN TOHA release predictions because the zips contain predictions for both PB0 and PBALL.