### PR TITLE
Fix the bug with "days_" columns + make edits to rebuild PGDL/PB0 metrics

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -30,7 +30,7 @@ targets:
       - 1_fetch/out/pgdl_matched_to_observations.zip
   
   sb_dl_date:
-   command: c(I("2020-04-29"))
+   command: c(I("2021-02-19"))
   
   ##-- Download files for mntoha data release --##
   

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -71,10 +71,11 @@ targets:
       site_file_yml = "2_process/out/2_pgdl_grp_tasks_completed.yml",
       ice_file_yml = "2_process/out/iceflags_unzipped.yml",
       n_cores = 40,
+      morphometry = morphometry,
+      temp_ranges = temp_ranges,
       '2_process/src/calculate_toha.R',
-      '3_summarize/src/annual_thermal_metrics.R')
-    depends:
-      - temp_ranges
+      '3_summarize/src/annual_thermal_metrics.R',
+      '3_summarize/src/do_annual_thermal_metric_tasks.R')
   
   3_summarize/out/annual_metrics_pb0.csv:
     command: do_annual_metrics_multi_lake(
@@ -82,10 +83,11 @@ targets:
       site_file_yml = "2_process/out/2_pb0_grp_tasks_completed.yml",
       ice_file_yml = "2_process/out/iceflags_unzipped.yml",
       n_cores = 40,
+      morphometry = morphometry,
+      temp_ranges = temp_ranges,
       '2_process/src/calculate_toha.R',
-      '3_summarize/src/annual_thermal_metrics.R')
-    depends:
-      - temp_ranges
+      '3_summarize/src/annual_thermal_metrics.R',
+      '3_summarize/src/do_annual_thermal_metric_tasks.R')
 
 ##-- Multi-state GLM2 Data Release --##
 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -303,7 +303,7 @@ calc_days_height_vol_within_range <- function(date, depth, wtr, hypso, temp_low,
       unpack(cols = Z1_Z2) %>% 
       mutate(daily_height_in_range = Z2 - Z1,
              daily_volume_in_range = calc_volume(Z1, Z2, hypso),
-             day_has_wtr_in_range = !is.na(daily_height_in_range)) %>% 
+             day_has_wtr_in_range = !is.na(daily_height_in_range) & daily_height_in_range > 0) %>% 
       summarize(!!sprintf("height_%s_%s", temp_low[i], temp_high[i]) := sum(daily_height_in_range, na.rm = TRUE),
                 !!sprintf("vol_%s_%s", temp_low[i], temp_high[i]) := sum(daily_volume_in_range, na.rm = TRUE),
                 !!sprintf("days_%s_%s", temp_low[i], temp_high[i]) := sum(day_has_wtr_in_range))

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -25,7 +25,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_file_yml, ice_file_y
   
   temp_ranges_file <- sprintf("temp_ranges.rds")
   saveRDS(temp_ranges, temp_ranges_file)
-  
+
   # Define task table rows
   tasks <- tibble(wtr_filename = site_files) %>% 
     extract(wtr_filename, c('prefix','site_id','suffix'), site_file_regex, remove = FALSE) %>% 
@@ -83,7 +83,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_file_yml, ice_file_y
     task_plan = task_plan,
     makefile = task_makefile,
     sources = c(...),
-    packages = c('tidyverse', 'purrr', 'readr', 'scipiper'),
+    packages = c('tidyverse', 'purrr', 'readr', 'scipiper', 'feather'),
     final_targets = final_target,
     finalize_funs = 'combine_thermal_metrics',
     as_promises = TRUE,


### PR DESCRIPTION
Three things happened in this PR:

1. Gretchen pointed out a bug in the code for how we calculated `day_has_wtr_in_range` where we assumed anything non-NA meant that the day saw temps in that range within the profile BUT [a change to how `find_Z1_Z2` worked](https://github.com/USGS-R/lake-temperature-out/commit/33a558447308074e9368e53661238150499de744) caused an issue with that approach where 0s could be returned and we didn't adjust for that before. This now treats 0s as they should be.
2.  Forgot to make the appropriate updates for PB0 & PGDL annual metrics targets [after adding the multistate targets](https://github.com/USGS-R/lake-temperature-out/pull/51) for annual metrics. So, had to make those in order to rebuild.
3. Updated the `sb` date to force the pipeline to re-download SB temperature files bc Hayley had updated them after adding in the PGDL profile sorting step to force PGDL outputs to be monotonic.