### PR TITLE
add date_below_5 to thermal metrics

### DIFF
--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -382,7 +382,7 @@ calc_first_day_below_temp <- function(date, wtr_surf, temperatures, peak_temp_dt
   
   date_below_df <- lapply(temperatures, function(temp) {
     first_day_below_temp <- dates_post_summer[water_surf_post_summer < temp] %>% head(1) %>% format("%j") %>% as.numeric()
-    if(length(first_day_below_temp) == 0) first_day_below_temp <- NA # Return NA if that temp was never reached
+    if(length(first_day_below_temp) == 0) first_day_below_temp <- NA # Return NA if the surface temp never dropped below the temp during the year
     return(first_day_below_temp)
   }) %>% data.frame()
   names(date_below_df) <- sprintf("date_below_%s", temperatures)


### PR DESCRIPTION
Only one temperature was requested, but I wrote the code to be able to handle multiple "below" temperatures (similar to how `date_over` is set up). Successfully ran and tested this on 112 sites (middle chart is the date_below_5 minus peak_temp_dt)

![image](https://user-images.githubusercontent.com/13220910/109846800-2791f880-7c14-11eb-92a7-e3174f104f71.png)


