### PR TITLE
Ice on fix

### DIFF
--- a/1_fetch.yml
+++ b/1_fetch.yml
@@ -30,7 +30,7 @@ targets:
       - 1_fetch/out/pgdl_matched_to_observations.zip
   
   sb_dl_date:
-   command: c(I("2021-02-19"))
+   command: c(I("2021-04-08"))
   
   ##-- Download files for mntoha data release --##
   

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -185,24 +185,25 @@ filter_out_partial_yrs <- function(df) {
 winter_dur_0_4 <- function(this_yr_date, this_yr_wtr, this_yr_depth, prev_yr_data) {
   
   if(nrow(prev_yr_data) == 0) {
-    # TODO: should this allow partial data? For example, if the dates started in 
-    #   May, it may return 0 for that year. May need to skip and return NA.
-    start_date <- min(this_yr_date)
+    # Return NA if there is not enough data from the previous year
+    # This is usually an issue for the first year in a dataset 
+    return(NA)
   } else {
+    
     start_date <- unique(sprintf("%s-10-30", format(prev_yr_data$date, "%Y")))
+    
+    end_date <- unique(sprintf("%s-06-30", format(this_yr_date, "%Y")))
+    
+    data.frame(date = c(prev_yr_data$date, this_yr_date), 
+               wtr = c(prev_yr_data$wtr, this_yr_wtr),
+               depth = c(prev_yr_data$depth, this_yr_depth)) %>% 
+      filter(
+        date >= start_date & date <= end_date, # Oct 30 prev year to June 30 this year
+        depth == 0, # surface water
+        wtr < 4 # TODO: What about negatives? Should it be 0-4 or just less than 4?
+      ) %>% 
+      nrow()
   }
-  end_date <- unique(sprintf("%s-06-30", format(this_yr_date, "%Y")))
-  
-  data.frame(date = c(prev_yr_data$date, this_yr_date), 
-             wtr = c(prev_yr_data$wtr, this_yr_wtr),
-             depth = c(prev_yr_data$depth, this_yr_depth)) %>% 
-    filter(
-      date >= start_date & date <= end_date, # Oct 30 prev year to June 30 this year
-      depth == 0, # surface water
-      wtr < 4 # TODO: What about negatives? Should it be 0-4 or just less than 4?
-    ) %>% 
-    nrow()
-   
 }
 
 #' @description Coefficient of Variation of surface temperature from a range of days 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -64,8 +64,9 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
       peak_temp = max(wtr_surf_daily, na.rm = TRUE),
       peak_temp_dt = date[which.max(wtr_surf_daily)],
 
-      ice_on_date = get_ice_on(date, ice, peak_temp_dt),
-      ice_off_date = get_ice_off(date, ice, peak_temp_dt),
+      # Find ice on and ice off at the same time since both need to use the longest period of ice calc.
+      # Also, pass in last years data so that ice on captures potential December (or earlier dates from that year's winter).
+      ice_onoff_date = get_ice_onoff(date, ice, peak_temp_dt, prev_yr_ice = get_last_years_data(unique(year), data_ready_with_flags)),
 
       winter_dur_0_4 = winter_dur_0_4(date, wtr, depth, prev_yr_data=get_last_years_data(unique(year), data_ready)),
       coef_var_31_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(31,60)),
@@ -111,7 +112,7 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
       
       .groups = "keep" # suppresses message about regrouping
     ) %>% 
-    unpack(cols = c(mean_surf_mon, max_surf_mon, mean_bot_mon, max_bot_mon,
+    unpack(cols = c(ice_onoff_date, mean_surf_mon, max_surf_mon, mean_bot_mon, max_bot_mon,
                     mean_surf_jas, max_surf_jas, mean_bot_jas, max_bot_jas,
                     date_over_temps, date_below_temps, 
                     days_height_vol_in_range, metalimnion_derivatives)) %>%
@@ -496,44 +497,49 @@ is_in_longest_consective_chunk <- function(bool_vec) {
   }
 }
 
-get_ice_on <- function(date, ice, peak_temp_dt) {
+get_ice_onoff <- function(date, ice, peak_temp_dt, prev_yr_ice) {
   
-  # TODO: does this need to involve past and future year info like the function
-  #   from mda.lakes? https://github.com/USGS-R/mda.lakes/blob/afb436e047d2a9ca30dfdeae13745d2ee5109455/R/get_ice_onoff.R#L17
+  # Uses the current year's data plus some from the previous year
+  # similar to the function from mda.lakes:
+  #   https://github.com/USGS-R/mda.lakes/blob/afb436e047d2a9ca30dfdeae13745d2ee5109455/R/get_ice_onoff.R#L17
+  
+  # Add in last year's data that counts towards this year's winter which is post-peak 
+  #   temp. However, we can't easily pass in peak of previous year (`lag` doesn't work 
+  #   that way within `summarize`) so we are using July 1 as a safe date to capture all
+  #   dates with ice from the previous year since it likely hasn't started to form yet.
+  date_last <- prev_yr_ice$date
+  ice_last <- prev_yr_ice$ice
+  yr_last <- unique(format(date_last, "%Y"))
+  assumed_post_peak_dt_last <- as.Date(sprintf("%s-07-01", yr_last))
+  date_last_winter <- date_last[date_last >= assumed_post_peak_dt_last]
+  ice_last_winter <- ice_last[date_last >= assumed_post_peak_dt_last]
+  
+  # Now keep only dates from this year before the peak temperature
+  #   which would be when ice melts ("ice off")
+  date_first_half <- date[date <= peak_temp_dt]
+  ice_first_half <- ice[date <= peak_temp_dt]
+  
+  # Combine last year's dates with this year to get all the possible
+  #   values for ice data in this year's winter
+  date_all <- c(date_last_winter, date_first_half)
+  ice_all <- c(ice_last_winter, ice_first_half)
   
   # Need one date & ice value per day (not per depth & day)
-  date_unique <- unique_day(date)
-  ice_unique <- unique_day_data(date, ice)
+  date_unique <- unique_day(date_all)
+  ice_unique <- unique_day_data(date_all, ice_all)
   
-  # Second half of year, which would be when ice forms ("ice on")
-  date_second_half <- date_unique[date_unique > peak_temp_dt]
-  ice_second_half <- ice_unique[date_unique > peak_temp_dt]
+  # If there is no ice present during that part of the year, there is no ice on or ice off date because it wasn't there
+  if(!any(ice_unique)) {
+    ice_on <- as.Date(NA)
+    ice_off <- as.Date(NA)
+  } else {
+    # Find longest ice period during winter dates for this year
+    dates_in_ice_period <- date_unique[which(is_in_longest_consective_chunk(ice_unique))]
+    ice_on <- head(dates_in_ice_period, 1)
+    ice_off <- tail(dates_in_ice_period, 1)
+  }
   
-  # If there is no ice present during that part of the year, there is no ice off date because it wasn't there
-  if(!any(ice_second_half)) return(as.Date(NA)) #TODO: or what should we return?
-  
-  # Find start of longest ice period during second half of the year
-  ice_on <- head(which(is_in_longest_consective_chunk(ice_second_half)), 1)
-  return(date_second_half[ice_on])
-  
-}
-
-get_ice_off <- function(date, ice, peak_temp_dt) {
-  
-  # Need one date & ice value per day (not per depth & day)
-  date_unique <- unique_day(date)
-  ice_unique <- unique_day_data(date, ice)
-
-  # First half of year, which would be when ice melts ("ice off")
-  date_first_half <- date_unique[date_unique <= peak_temp_dt]
-  ice_first_half <- ice_unique[date_unique <= peak_temp_dt]
-  
-  # If there is no ice present during that part of the year, there is no ice off date because it wasn't there
-  if(!any(ice_first_half)) return(as.Date(NA)) #TODO: or do we return the first day of the year?
-  
-  # Find end of longest ice period during first half of the year
-  ice_off <- tail(which(is_in_longest_consective_chunk(ice_first_half)), 1)
-  return(date_first_half[ice_off])
+  return(data.frame(ice_on_date = ice_on, ice_off_date = ice_off))
   
 }
 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -69,8 +69,8 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
       ice_onoff_date = get_ice_onoff(date, ice, peak_temp_dt, prev_yr_ice = get_last_years_data(unique(year), data_ready_with_flags)),
 
       winter_dur_0_4 = winter_dur_0_4(date, wtr, depth, prev_yr_data=get_last_years_data(unique(year), data_ready)),
-      coef_var_31_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(31,60)),
-      coef_var_1_30 = coef_var(date, wtr_surf_daily, ice_off_date = ice_off_date, c(1,30)),
+      coef_var_31_60 = coef_var(date, wtr_surf_daily, ice_off_date = ice_onoff_date$ice_off_date, c(31,60)),
+      coef_var_1_30 = coef_var(date, wtr_surf_daily, ice_off_date = ice_onoff_date$ice_off_date, c(1,30)),
 
       # Metrics that deal with the stratified period
       stratification_onset_yday = stratification_onset_yday(date, in_stratified_period),
@@ -81,7 +81,7 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
       gdd_wtr_0c = calc_gdd(date, wtr_surf_daily, 0),
       gdd_wtr_5c = calc_gdd(date, wtr_surf_daily, 5),
       gdd_wtr_10c = calc_gdd(date, wtr_surf_daily, 10),
-      schmidt_daily_annual_sum = schmidt_daily_annual_sum(date, depth, wtr, ice_on_date, ice_off_date, hypso),
+      schmidt_daily_annual_sum = schmidt_daily_annual_sum(date, depth, wtr, ice, hypso),#_onoff_date$ice_on_date, ice_onoff_date$ice_off_date, hypso),
 
       # The following section of metrics return a data.frame per summarize command and
       #   are unpacked into their real columns after using `unpack`
@@ -104,7 +104,7 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
                                                                    temp_high = temp_ranges$Temp_High),
 
       spring_days_in_10.5_15.5 = spring_days_incub(date, wtr_surf_daily, c(10.5, 15.5)),
-      post_ice_warm_rate = post_ice_warm_rate(date, wtr_surf_daily, ice_off_date),
+      post_ice_warm_rate = post_ice_warm_rate(date, wtr_surf_daily, ice_onoff_date$ice_off_date),
       date_over_temps = calc_first_day_above_temp(date, wtr_surf_daily, temperatures = c(8.9, 16.7, 18, 21)), # Returns a df and needs to be unpacked below
       date_below_temps = calc_first_day_below_temp(date, wtr_surf_daily, temperatures = c(5), peak_temp_dt),
       metalimnion_derivatives = calc_metalimnion_derivatives(date, depth, wtr, in_stratified_period, stratification_duration, hypso),

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -67,7 +67,9 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
       
       # Find ice on and ice off at the same time since both need to use the longest period of ice calc.
       # Also, pass in last years data so that ice on captures potential December (or earlier dates from that year's winter).
-      ice_onoff_date = get_ice_onoff(date, ice, peak_temp_dt, prev_yr_ice = get_last_years_data(unique(year), data_ready_with_flags))
+      ice_onoff_date = get_ice_onoff(date, ice, peak_temp_dt, prev_yr_ice = get_last_years_data(unique(year), data_ready_with_flags)),
+      
+      .groups = "keep" # suppresses message about regrouping
     ) %>% 
     unpack(ice_onoff_date) %>% 
     ungroup() %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -565,6 +565,12 @@ get_ice_onoff <- function(date, ice, peak_temp_dt, prev_yr_ice) {
     dates_in_ice_period <- date_unique[which(is_in_longest_consective_chunk(ice_unique))]
     ice_on <- head(dates_in_ice_period, 1)
     ice_off <- tail(dates_in_ice_period, 1)
+    
+    # ice_off should not be in the year before, so should be NA 
+    # if there are no ice off dates in the current year.
+    if(as.numeric(format(ice_off, "%Y")) != unique(as.numeric(format(date, "%Y")))) {
+      ice_off <- as.Date(NA)
+    }
   }
   
   return(data.frame(ice_on_date = ice_on, ice_off_date = ice_off))

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -574,6 +574,12 @@ get_ice_onoff <- function(date, ice, peak_temp_dt, prev_yr_ice) {
     }
   }
   
+  if(nrow(prev_yr_ice) == 0) {
+    # Return NA for ice_on if there was not any data from the previous year
+    # This is usually an issue for the first year in a dataset 
+    ice_on <- as.Date(NA)
+  }
+  
   return(data.frame(ice_on_date = ice_on, ice_off_date = ice_off))
   
 }

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -92,7 +92,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_file_yml, ice_file_y
   # Build the tasks
   loop_tasks(task_plan = task_plan,
              task_makefile = task_makefile,
-             num_tries = 1,
+             num_tries = 3,
              n_cores = n_cores)
   
   # Clean up files created


### PR DESCRIPTION
Jonah noticed an issue where our `ice_on_date` values were never after Dec 31. After investigating, I realized that our code's assumption of ice_on was incorrect. The following changes have been made:

1. `ice_on_date` now refers to the current year's winter season instead of the calendar year. Therefore, for each year, the `ice_on_date` should now be earlier than the `ice_off_date`. 
2. The function, `get_ice_onoff` now accepts the previous year's ice data so that it can capture ice_on dates that may have happened in December (or earlier) of the previous year. It returns a data.frame with both `ice_on_date` and `ice_off_date` as columns so that they could share the calculation for finding the longest ice period. The data.frame is later unpacked so that `ice_on_date` and `ice_off_date` are columns in the final data.
3. Since the `ice_on_date` for each year now refers to that year's winter season, the calculation for `open_water_duration` had to change. It needs to use the current year's `ice_off_date` but the next year's `ice_on_date` to determine how long the open water season for the current year was.

The `ice_on_date` is different from [how `mda.lakes` computes `ice_on_date`](https://github.com/USGS-R/mda.lakes/blob/afb436e047d2a9ca30dfdeae13745d2ee5109455/R/get_ice_onoff.R), where for each year, `ice_on_date` is later in the year than `ice_off_date`. This deviation was purposeful so that we now match [how the Wisconsin State Climatology Office reports ice-on and ice-off](https://www.aos.wisc.edu/~sco/lakes/icesum19.html), which uses the winter season and not the calendar year.