### PR TITLE
Some refactoring for `calculate_annual_metrics_per_lake()`: use arrow + handle different columns + speed up

### DIFF
--- a/2_process.yml
+++ b/2_process.yml
@@ -1,11 +1,11 @@
 target_default: 2_process
 
 packages:
+  - arrow
   - dplyr
   - tidyr
   - scipiper
   - readr
-  - feather
   - purrr
 
 sources:

--- a/2_process/src/calculate_toha.R
+++ b/2_process/src/calculate_toha.R
@@ -3,7 +3,7 @@
 
 calculate_toha_per_lake <- function(target_name, site_data_fn, morphometry) {
   
-  site_data <- feather::read_feather(site_data_fn)
+  site_data <- arrow::read_feather(site_data_fn)
   wtr_cols <- grep("temp_", names(site_data))
   
   # When adding obs data, some sites don't make it past the filtering criteria

--- a/2_process/src/do_lake_toha_tasks.R
+++ b/2_process/src/do_lake_toha_tasks.R
@@ -68,7 +68,7 @@ do_lake_toha_tasks <- function(final_target, task_df_fn, n_cores, ...) {
     makefile=task_makefile,
     include='remake.yml',
     sources=c(...),
-    packages=c("purrr", "dplyr", "mda.lakes", "feather", "rLakeAnalyzer"),
+    packages=c("purrr", "dplyr", "mda.lakes", "arrow", "rLakeAnalyzer"),
     final_targets = final_target,
     as_promises = TRUE,
     tickquote_combinee_objects = TRUE

--- a/2_process/src/do_lakegroup_tasks.R
+++ b/2_process/src/do_lakegroup_tasks.R
@@ -76,7 +76,7 @@ do_lakegroup_tasks <- function(final_target, task_ids, irradiance_zips, clarity_
     makefile=task_makefile,
     include='remake.yml',
     sources=c(...),
-    packages=c("purrr", "dplyr", "readr", "feather"),
+    packages=c("purrr", "dplyr", "readr", "arrow"),
     final_targets = final_target,
     finalize_funs = "indicate_file_dataframes",
     as_promises = TRUE,

--- a/2_process/src/do_obs_lakes_tasks.R
+++ b/2_process/src/do_obs_lakes_tasks.R
@@ -85,7 +85,7 @@ do_obs_lake_tasks <- function(target_name, task_df_fn, irr_df_fn, k0_df_fn, obs_
     makefile = task_makefile,
     include = 'remake.yml',
     sources = c(...),
-    packages = c("purrr", "dplyr", "mda.lakes", "feather", "rLakeAnalyzer", "readr"),
+    packages = c("purrr", "dplyr", "mda.lakes", "arrow", "rLakeAnalyzer", "readr"),
     final_targets = c(target_name),
     finalize_funs = c('combine_obs_toha'),
     as_promises = TRUE,

--- a/2_process/src/observed_data_helpers_munge.R
+++ b/2_process/src/observed_data_helpers_munge.R
@@ -3,7 +3,7 @@ munge_observed_data <- function(target_name, obs_data_fn, irr_data_fn, kd_data_f
   
   options(dplyr.summarise.inform = FALSE) # new dplyr 1.0 messaging is annoying so turn it off
   
-  observed_dat <- read_feather(obs_data_fn) %>% 
+  observed_dat <- arrow::read_feather(obs_data_fn) %>% 
     filter_observed_data() %>% 
     reformat_observed_data() %>% 
     join_observed_data(irr_data_fn, kd_data_fn) %>% 

--- a/3_summarize.yml
+++ b/3_summarize.yml
@@ -1,8 +1,8 @@
 target_default: 3_summarize
 
 packages:
+  - arrow
   - dplyr
-  - feather
   - readr
   - tidyr
 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -4,7 +4,9 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
   start_tm <- Sys.time()
   
   if(tools::file_ext(site_file) == "feather") {
-    wtr_data <- read_feather(site_file) %>% 
+    # Feathers created with `arrow` fail when reading in with `feather::read_feather()`
+    # But feathers created with `feather` don't fail when reading in with `arrow:read_feather()`
+    wtr_data <- arrow::read_feather(site_file) %>% 
       select(site_id, date = DateTime, starts_with("temp_"))
   } else if(tools::file_ext(site_file) == "csv") {
     wtr_data <- read_csv(site_file) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -8,6 +8,12 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
     # But feathers created with `feather` don't fail when reading in with `arrow:read_feather()`
     wtr_data <- arrow::read_feather(site_file) %>% 
       select(site_id, date = DateTime, starts_with("temp_"))
+      {
+        # Add the `site_id` column if it isn't present using the 
+        if(!"site_id" %in% names(.))
+          mutate(., site_id = site_id)
+        else .
+      } %>% 
   } else if(tools::file_ext(site_file) == "csv") {
     wtr_data <- read_csv(site_file) %>% 
       mutate(site_id = site_id) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -7,13 +7,15 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
     # Feathers created with `arrow` fail when reading in with `feather::read_feather()`
     # But feathers created with `feather` don't fail when reading in with `arrow:read_feather()`
     wtr_data <- arrow::read_feather(site_file) %>% 
-      select(site_id, date = DateTime, starts_with("temp_"))
       {
         # Add the `site_id` column if it isn't present using the 
         if(!"site_id" %in% names(.))
           mutate(., site_id = site_id)
         else .
       } %>% 
+      # Different outputs for modeled lake temp have different colnames for the date
+      rename(date = matches("DateTime|time")) %>% 
+      select(site_id, date, starts_with("temp_"))
   } else if(tools::file_ext(site_file) == "csv") {
     wtr_data <- read_csv(site_file) %>% 
       mutate(site_id = site_id) %>% 

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -620,15 +620,14 @@ find_Z1_Z2 <- function(wtr, depth, wtr_upper_bound, wtr_lower_bound) {
       # which causes approx to throw an error. Return NAs for the Zs and let
       # checks below determine if benth area is all (or partially) above or 
       # below the lake and set Zs based on that.
-      Z1_Z2 <- c(NA,NA)
+      Z1 <- rep(NA, length(wtr_upper_bound))
+      Z2 <- rep(NA, length(wtr_lower_bound))
     } else {
       # Had to explicitly add `ties=mean` to suppress warning
       # https://community.rstudio.com/t/conditionally-interpolate-values-for-one-data-frame-based-on-another-lookup-table-per-group-solved/40922/5
-      Z1_Z2 <- approx(wtr, depth, xout=c(wtr_upper_bound, wtr_lower_bound), ties=mean)$y
+      Z1 <- approx(wtr, depth, xout=wtr_upper_bound, ties=mean)$y
+      Z2 <- approx(wtr, depth, xout=wtr_lower_bound, ties=mean)$y
     }
-    
-    Z1 <- Z1_Z2[1]
-    Z2 <- Z1_Z2[2]
     
     wtr_surface <- wtr[which.min(depth)] # wtr_surface will be whatever the top-most wtr is
     wtr_bottom <- wtr[which.max(depth)] # wtr_bottom will be whatever the bottom-most wtr is
@@ -653,8 +652,8 @@ find_Z1_Z2 <- function(wtr, depth, wtr_upper_bound, wtr_lower_bound) {
     Z2[extends_below_lake] <- z_max
   } else {
     # If there is only one non-NA wtr, then we can't figure out where Z1 and Z2 would be
-    Z1 <- NA
-    Z2 <- NA
+    Z1 <- rep(NA, length(wtr_upper_bound))
+    Z2 <- rep(NA, length(wtr_lower_bound))
   }
   return(tibble(Z1 = Z1, Z2 = Z2))
 }

--- a/3_summarize/src/annual_thermal_metrics.R
+++ b/3_summarize/src/annual_thermal_metrics.R
@@ -78,6 +78,8 @@ calculate_annual_metrics_per_lake <- function(out_ind, site_id, site_file, ice_f
   # Need these summaries to be used by functions in the next one. Biggest reason is that other functions
   # need access to the following year's ice_on_date and can't use lead/lag unless outside of `summarize`
   pre_summary_data <- data_ready_with_flags %>% 
+    # `site_id` included here just so it exists in the final output; there should only be one site_id
+    # in the file passed to this function
     group_by(site_id, year) %>% 
     summarize(
       # Maximum observed surface temperature & corresponding date

--- a/3_summarize/src/do_annual_thermal_metric_tasks.R
+++ b/3_summarize/src/do_annual_thermal_metric_tasks.R
@@ -83,7 +83,7 @@ do_annual_metrics_multi_lake <- function(final_target, site_file_yml, ice_file_y
     task_plan = task_plan,
     makefile = task_makefile,
     sources = c(...),
-    packages = c('tidyverse', 'purrr', 'readr', 'scipiper', 'feather'),
+    packages = c('tidyverse', 'purrr', 'readr', 'scipiper', 'arrow'),
     final_targets = final_target,
     finalize_funs = 'combine_thermal_metrics',
     as_promises = TRUE,


### PR DESCRIPTION
This is the start to #57 in that the code for `calculate_annual_metrics_per_lake()` can handle the incoming `site_file` that is missing a `site_id` column, has the dates stored in a `time` column, and includes an `ice` column rather than a separate `ice_file`. It does not change the pipeline to incorporate the new GLM outputs.

It also addresses the biggest culprit of slowness for #45. The changes that increased speed were fully vectorizing `find_Z1_Z2()` and using data.table for all the summarization (which meant pulling the step out from the big `group_by()` + `summarize()` chain and into a standalone step that is joined after. It is noted [here](https://github.com/USGS-R/lake-temperature-out/issues/45#issuecomment-1039730850), but this refactor took our `calculate_annual_metrics_per_lake()` from taking 18 min for the 60 years of data (1981-2000 + 2040-2059 + 2080-2099) to taking only 2.5 min!

Finally, this code switches any instance of `feather::read_feather()` to `arrow::read_feather()` to update to our group's current best practice.