### PR TITLE
add packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,10 @@ RUN install2.r --error \
   tidyr \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
+RUN install2.r --error \
+  doParallel \
+  && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+
 # Fix umask problems with RStudio in singularity
 RUN echo "Sys.umask(mode=002)" >> /usr/local/lib/R/etc/Rprofile.site
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN Rscript -e 'library(remotes); \
 RUN install2.r --error \
   arrow \
   data.table \
+  doParallel \
   dplyr \
   foreach \
   jsonlite \
@@ -35,13 +36,10 @@ RUN install2.r --error \
   purrr \
   readr \
   retry \
+  rLakeAnalyzer \
   RNetCDF \
   sbtools \
   tidyr \
-  && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
-
-RUN install2.r --error \
-  doParallel \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # Fix umask problems with RStudio in singularity

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN install2.r --error \
   arrow \
   data.table \
   dplyr \
+  foreach \
   jsonlite \
   ncdfgeom \
   purrr \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   run_lake_metrics:
-    image: jrossusgs/lake-temperature-out:v0.2
+    image: jrossusgs/lake-temperature-out:v0.2.1
     build:
       context: .
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   run_lake_metrics:
-    image: jrossusgs/lake-temperature-out:v0.2.1
+    image: jrossusgs/lake-temperature-out:v0.2.2
     build:
       context: .
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   run_lake_metrics:
-    image: jrossusgs/lake-temperature-out:v0.1
+    image: jrossusgs/lake-temperature-out:v0.2
     build:
       context: .
     ports:

--- a/glm3pb0_gcms_singularity.slurm
+++ b/glm3pb0_gcms_singularity.slurm
@@ -13,6 +13,6 @@
 module load singularity
 
 srun singularity exec \
-    lake-temperature-out_v0.1.sif \
+    lake-temperature-out.sif \
     Rscript glm3pb0_gcms_run.R
 


### PR DESCRIPTION
This adds the `foreach` library to the docker image, and sets up the slurm launch script to use a generic container name so that container version management can be done with symlinks. Creating it here as a placeholder - once the pipeline is known to be working, we can review it.